### PR TITLE
Improve GatewayError printing

### DIFF
--- a/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
+++ b/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
@@ -402,6 +402,11 @@ public class DiscordGatewayClient : IDisposable
                     message
                 );
 
+                if (iterationResult.Inner is { IsSuccess: false })
+                {
+                    _log.LogError("{Error}", iterationResult.Inner.Error);
+                }
+
                 shouldTerminate = true;
                 return false;
             }


### PR DESCRIPTION
I just extended the GatewayError handling in the DiscordGatewayClient to also
print the inner error to console.

This shows for example the cause why the gateway endpoint was not able to get.