### PR TITLE
Fix validation for MinValue and MaxValue attributes

### DIFF
--- a/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
@@ -608,7 +608,7 @@ public static class CommandTreeExtensions
             var minValue = parameter.Parameter.GetCustomAttribute<MinValueAttribute>();
             var maxValue = parameter.Parameter.GetCustomAttribute<MaxValueAttribute>();
 
-            if (discordType is not Integer or Number && (minValue is not null || maxValue is not null))
+            if ((discordType is not Integer && discordType is not Number) && (minValue is not null || maxValue is not null))
             {
                 return new UnsupportedParameterFeatureError
                 (

--- a/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
@@ -608,7 +608,7 @@ public static class CommandTreeExtensions
             var minValue = parameter.Parameter.GetCustomAttribute<MinValueAttribute>();
             var maxValue = parameter.Parameter.GetCustomAttribute<MaxValueAttribute>();
 
-            if ((discordType is not Integer && discordType is not Number) && (minValue is not null || maxValue is not null))
+            if (discordType is not (Number or Integer) && (minValue is not null || maxValue is not null))
             {
                 return new UnsupportedParameterFeatureError
                 (

--- a/Tests/Remora.Discord.Commands.Tests/Data/Valid/NumericalParameterWithValueConstraints.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Data/Valid/NumericalParameterWithValueConstraints.cs
@@ -1,0 +1,128 @@
+//
+//  NumericalParameterWithValueConstraints.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Remora.Commands.Attributes;
+using Remora.Commands.Groups;
+using Remora.Discord.Commands.Attributes;
+using Remora.Results;
+
+namespace Remora.Discord.Commands.Tests.Data.Valid;
+
+/// <summary>
+/// Defines various permutations of groups with commands that have string parameters with constraints on their input
+/// lengths.
+/// </summary>
+public class NumericalParameterWithValueConstraints
+{
+    /// <summary>
+    /// Defines a command with a minimum length constraint set.
+    /// </summary>
+    public class MinValueConstraint : CommandGroup
+    {
+        /// <summary>
+        /// The command.
+        /// </summary>
+        /// <param name="parameter">The annotated parameter.</param>
+        /// <returns>Nothing.</returns>
+        [Command("min")]
+        public Task<IResult> Command([MinValue(0)] ulong parameter)
+            => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Defines a command with a maximum length constraint set.
+    /// </summary>
+    public class MaxValueConstraint : CommandGroup
+    {
+        /// <summary>
+        /// The command.
+        /// </summary>
+        /// <param name="parameter">The annotated parameter.</param>
+        /// <returns>Nothing.</returns>
+        [Command("min")]
+        public Task<IResult> Command([MaxValue(1)] ulong parameter)
+            => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Defines a command with a minimum and maximum length constraint set.
+    /// </summary>
+    public class MinAndMaxValueConstraint : CommandGroup
+    {
+        /// <summary>
+        /// The command.
+        /// </summary>
+        /// <param name="parameter">The annotated parameter.</param>
+        /// <returns>Nothing.</returns>
+        [Command("min")]
+        public Task<IResult> Command([MinValue(0), MaxValue(1)] ulong parameter)
+            => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Defines a command with a minimum length constraint set.
+    /// </summary>
+    public class MinFloatValueConstraint : CommandGroup
+    {
+        /// <summary>
+        /// The command.
+        /// </summary>
+        /// <param name="parameter">The annotated parameter.</param>
+        /// <returns>Nothing.</returns>
+        [Command("min")]
+        public Task<IResult> Command([MinValue(0)] float parameter)
+            => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Defines a command with a maximum length constraint set.
+    /// </summary>
+    public class MaxFloatValueConstraint : CommandGroup
+    {
+        /// <summary>
+        /// The command.
+        /// </summary>
+        /// <param name="parameter">The annotated parameter.</param>
+        /// <returns>Nothing.</returns>
+        [Command("min")]
+        public Task<IResult> Command([MaxValue(1)] float parameter)
+            => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Defines a command with a minimum and maximum length constraint set.
+    /// </summary>
+    public class MinAndMaxFloatValueConstraint : CommandGroup
+    {
+        /// <summary>
+        /// The command.
+        /// </summary>
+        /// <param name="parameter">The annotated parameter.</param>
+        /// <returns>Nothing.</returns>
+        [Command("min")]
+        public Task<IResult> Command([MinValue(0), MaxValue(1)] float parameter)
+            => throw new NotImplementedException();
+    }
+}

--- a/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
@@ -750,7 +750,7 @@ public class CommandTreeExtensionTests
                 var command = commands.Single();
                 var parameter = command.Options.Value.Single();
 
-                Assert.Equal(0l, parameter.MinValue.Value);
+                Assert.Equal(0L, parameter.MinValue.Value);
                 Assert.False(parameter.MaxValue.HasValue);
             }
 

--- a/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
@@ -819,7 +819,7 @@ public class CommandTreeExtensionTests
                 var command = commands.Single();
                 var parameter = command.Options.Value.Single();
 
-                Assert.Equal(0f, parameter.MinValue.Value);
+                Assert.Equal(0l, parameter.MinValue.Value);
                 Assert.False(parameter.MaxValue.HasValue);
             }
 
@@ -842,7 +842,7 @@ public class CommandTreeExtensionTests
                 var command = commands.Single();
                 var parameter = command.Options.Value.Single();
 
-                Assert.Equal(1f, parameter.MaxValue.Value);
+                Assert.Equal(1l, parameter.MaxValue.Value);
                 Assert.False(parameter.MinValue.HasValue);
             }
 
@@ -865,8 +865,8 @@ public class CommandTreeExtensionTests
                 var command = commands.Single();
                 var parameter = command.Options.Value.Single();
 
-                Assert.Equal(0f, parameter.MinValue.Value);
-                Assert.Equal(1f, parameter.MaxValue.Value);
+                Assert.Equal(0l, parameter.MinValue.Value);
+                Assert.Equal(1l, parameter.MaxValue.Value);
             }
         }
 

--- a/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
@@ -730,6 +730,144 @@ public class CommandTreeExtensionTests
                 Assert.Equal(0u, parameter.MinLength.Value);
                 Assert.Equal(1u, parameter.MaxLength.Value);
             }
+
+            /// <summary>
+            /// Tests whether the method responds appropriately to a successful case.
+            /// </summary>
+            [Fact]
+            public void CreatesMinValueConstrainedParametersCorrectly()
+            {
+                var builder = new CommandTreeBuilder();
+                builder.RegisterModule<NumericalParameterWithValueConstraints.MinValueConstraint>();
+
+                var tree = builder.Build();
+
+                var result = tree.CreateApplicationCommands();
+                ResultAssert.Successful(result);
+
+                var commands = result.Entity;
+
+                var command = commands.Single();
+                var parameter = command.Options.Value.Single();
+
+                Assert.Equal(0l, parameter.MinValue.Value);
+                Assert.False(parameter.MaxValue.HasValue);
+            }
+
+            /// <summary>
+            /// Tests whether the method responds appropriately to a successful case.
+            /// </summary>
+            [Fact]
+            public void CreatesMaxValueConstrainedParametersCorrectly()
+            {
+                var builder = new CommandTreeBuilder();
+                builder.RegisterModule<NumericalParameterWithValueConstraints.MaxValueConstraint>();
+
+                var tree = builder.Build();
+
+                var result = tree.CreateApplicationCommands();
+                ResultAssert.Successful(result);
+
+                var commands = result.Entity;
+
+                var command = commands.Single();
+                var parameter = command.Options.Value.Single();
+
+                Assert.Equal(1l, parameter.MaxValue.Value);
+                Assert.False(parameter.MinValue.HasValue);
+            }
+
+            /// <summary>
+            /// Tests whether the method responds appropriately to a successful case.
+            /// </summary>
+            [Fact]
+            public void CreatesMinAndMaxValueConstrainedParametersCorrectly()
+            {
+                var builder = new CommandTreeBuilder();
+                builder.RegisterModule<NumericalParameterWithValueConstraints.MinAndMaxValueConstraint>();
+
+                var tree = builder.Build();
+
+                var result = tree.CreateApplicationCommands();
+                ResultAssert.Successful(result);
+
+                var commands = result.Entity;
+
+                var command = commands.Single();
+                var parameter = command.Options.Value.Single();
+
+                Assert.Equal(0l, parameter.MinValue.Value);
+                Assert.Equal(1l, parameter.MaxValue.Value);
+            }
+
+            /// <summary>
+            /// Tests whether the method responds appropriately to a successful case.
+            /// </summary>
+            [Fact]
+            public void CreatesMinValueFloatConstrainedParametersCorrectly()
+            {
+                var builder = new CommandTreeBuilder();
+                builder.RegisterModule<NumericalParameterWithValueConstraints.MinFloatValueConstraint>();
+
+                var tree = builder.Build();
+
+                var result = tree.CreateApplicationCommands();
+                ResultAssert.Successful(result);
+
+                var commands = result.Entity;
+
+                var command = commands.Single();
+                var parameter = command.Options.Value.Single();
+
+                Assert.Equal(0f, parameter.MinValue.Value);
+                Assert.False(parameter.MaxValue.HasValue);
+            }
+
+            /// <summary>
+            /// Tests whether the method responds appropriately to a successful case.
+            /// </summary>
+            [Fact]
+            public void CreatesMaxValueFloatConstrainedParametersCorrectly()
+            {
+                var builder = new CommandTreeBuilder();
+                builder.RegisterModule<NumericalParameterWithValueConstraints.MaxFloatValueConstraint>();
+
+                var tree = builder.Build();
+
+                var result = tree.CreateApplicationCommands();
+                ResultAssert.Successful(result);
+
+                var commands = result.Entity;
+
+                var command = commands.Single();
+                var parameter = command.Options.Value.Single();
+
+                Assert.Equal(1f, parameter.MaxValue.Value);
+                Assert.False(parameter.MinValue.HasValue);
+            }
+
+            /// <summary>
+            /// Tests whether the method responds appropriately to a successful case.
+            /// </summary>
+            [Fact]
+            public void CreatesMinAndMaxFloatValueConstrainedParametersCorrectly()
+            {
+                var builder = new CommandTreeBuilder();
+                builder.RegisterModule<NumericalParameterWithValueConstraints.MinAndMaxFloatValueConstraint>();
+
+                var tree = builder.Build();
+
+                var result = tree.CreateApplicationCommands();
+                ResultAssert.Successful(result);
+
+                var commands = result.Entity;
+
+                var command = commands.Single();
+                var parameter = command.Options.Value.Single();
+
+                Assert.Equal(0f, parameter.MinValue.Value);
+                Assert.Equal(1f, parameter.MaxValue.Value);
+            }
         }
 
         /// <summary>

--- a/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
@@ -773,7 +773,7 @@ public class CommandTreeExtensionTests
                 var command = commands.Single();
                 var parameter = command.Options.Value.Single();
 
-                Assert.Equal(1l, parameter.MaxValue.Value);
+                Assert.Equal(1L, parameter.MaxValue.Value);
                 Assert.False(parameter.MinValue.HasValue);
             }
 
@@ -796,8 +796,8 @@ public class CommandTreeExtensionTests
                 var command = commands.Single();
                 var parameter = command.Options.Value.Single();
 
-                Assert.Equal(0l, parameter.MinValue.Value);
-                Assert.Equal(1l, parameter.MaxValue.Value);
+                Assert.Equal(0L, parameter.MinValue.Value);
+                Assert.Equal(1L, parameter.MaxValue.Value);
             }
 
             /// <summary>
@@ -819,7 +819,7 @@ public class CommandTreeExtensionTests
                 var command = commands.Single();
                 var parameter = command.Options.Value.Single();
 
-                Assert.Equal(0l, parameter.MinValue.Value);
+                Assert.Equal(0L, parameter.MinValue.Value);
                 Assert.False(parameter.MaxValue.HasValue);
             }
 
@@ -842,7 +842,7 @@ public class CommandTreeExtensionTests
                 var command = commands.Single();
                 var parameter = command.Options.Value.Single();
 
-                Assert.Equal(1l, parameter.MaxValue.Value);
+                Assert.Equal(1L, parameter.MaxValue.Value);
                 Assert.False(parameter.MinValue.HasValue);
             }
 
@@ -865,8 +865,8 @@ public class CommandTreeExtensionTests
                 var command = commands.Single();
                 var parameter = command.Options.Value.Single();
 
-                Assert.Equal(0l, parameter.MinValue.Value);
-                Assert.Equal(1l, parameter.MaxValue.Value);
+                Assert.Equal(0L, parameter.MinValue.Value);
+                Assert.Equal(1L, parameter.MaxValue.Value);
             }
         }
 


### PR DESCRIPTION
closes #234 

Added some tests and fixed the bug I found. While working on this I also noticed that the min and max value attributes can't be applied to integers, should this be changed?