### PR TITLE
Reword docs for attachments on interactions

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IInteractionMessageCallbackData.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IInteractionMessageCallbackData.cs
@@ -71,6 +71,9 @@ public interface IInteractionMessageCallbackData
     /// <summary>
     /// Gets the attachments attached to the message.
     /// </summary>
-    /// <remarks>Only relevant for message interactions.</remarks>
+    /// <remarks>This is only relevant for message interactions, and acts as a mapping
+    /// for uploaded and pre-existing files when creating an interaction response,
+    /// or updating an existing interaction message.
+    /// See https://discord.dev/reference#uploading-files for more information.</remarks>
     Optional<IReadOnlyList<IPartialAttachment>> Attachments { get; }
 }


### PR DESCRIPTION
The current documentation was very unclear in it's purpose, especially given that it's not intended to be set directly, which would result in an error.