### PR TITLE
Guard GetRequiredService call in try-catch in DispatchEventAsync

### DIFF
--- a/Backend/Remora.Discord.Gateway/Services/ResponderDispatchService.cs
+++ b/Backend/Remora.Discord.Gateway/Services/ResponderDispatchService.cs
@@ -326,11 +326,11 @@ public class ResponderDispatchService : IAsyncDisposable
                     async rt =>
                     {
                         await using var serviceScope = _services.CreateAsyncScope();
-                        var responder = (IResponder<TGatewayEvent>)serviceScope.ServiceProvider
-                            .GetRequiredService(rt);
-
                         try
                         {
+                            var responder = (IResponder<TGatewayEvent>)serviceScope.ServiceProvider
+                                .GetRequiredService(rt);
+
                             return await responder.RespondAsync(gatewayEvent.Data, ct);
                         }
                         catch (Exception e)


### PR DESCRIPTION
Normally, The call to IServiceProvider.GetRequiredService in ResponderDispatchService.DispatchEventAsync isn't guarded by a try-catch; however, GetService can throw an exception if the service activation fails for some reason. This causes an exception to be absorbed instead of rethrown as an Error (which exceptions thrown by RespondAsync _will_).

This PR moves the call to GetRequiredService into the `try`.

This PR does not fix the underlying problem of unguarded exceptions within DispatchEventAsync being swallowed; it is unclear to me what should happen in that case, however I believe putting the GetRequiredService call inside the `try` is still the correct fix for the immediate problem.