### PR TITLE
Add `buildClient` parameter to HostBuilderExtensions.AddDiscordService

### DIFF
--- a/Remora.Discord.Hosting/Extensions/HostBuilderExtensions.cs
+++ b/Remora.Discord.Hosting/Extensions/HostBuilderExtensions.cs
@@ -43,15 +43,16 @@ public static class HostBuilderExtensions
     /// </summary>
     /// <param name="hostBuilder">The host builder.</param>
     /// <param name="tokenFactory">A function that retrieves the bot token.</param>
+    /// <param name="buildClient">Extra options to configure the rest client.</param>
     /// <returns>The service collection, with the services added.</returns>
-    public static IHostBuilder AddDiscordService(this IHostBuilder hostBuilder, Func<IServiceProvider, string> tokenFactory)
+    public static IHostBuilder AddDiscordService(this IHostBuilder hostBuilder, Func<IServiceProvider, string> tokenFactory, Action<IHttpClientBuilder>? buildClient = null)
     {
         hostBuilder.ConfigureServices((_, serviceCollection) =>
         {
             serviceCollection.Configure(() => new DiscordServiceOptions());
 
             serviceCollection
-                .AddDiscordGateway(tokenFactory);
+                .AddDiscordGateway(tokenFactory, buildClient);
 
             serviceCollection
                 .TryAddSingleton<DiscordService>();


### PR DESCRIPTION
This PR adds the `buildClient` parameter from AddDiscordGateway to AddDiscordService; normally it's not possible to use the hosting framework if passing this parameter is desired.