### PR TITLE
Implement support for Selects V2

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/ComponentType.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/ComponentType.cs
@@ -41,7 +41,7 @@ public enum ComponentType
     Button = 2,
 
     /// <summary>
-    /// A menu of selectable options.
+    /// A menu of selectable strings.
     /// </summary>
     StringSelect = 3,
 

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/ComponentType.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/ComponentType.cs
@@ -43,10 +43,30 @@ public enum ComponentType
     /// <summary>
     /// A menu of selectable options.
     /// </summary>
-    SelectMenu = 3,
+    StringSelect = 3,
 
     /// <summary>
     /// A text field input.
     /// </summary>
-    TextInput = 4
+    TextInput = 4,
+
+    /// <summary>
+    /// A menu of selectable users.
+    /// </summary>
+    UserSelect = 5,
+
+    /// <summary>
+    /// A menu of selectable roles.
+    /// </summary>
+    RoleSelect = 6,
+
+    /// <summary>
+    /// A menu of selectable mentionables (roles, users).
+    /// </summary>
+    MentionableSelect = 7,
+
+    /// <summary>
+    /// A menu of selectable channels.
+    /// </summary>
+    ChannelSelect = 8
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IChannelSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IChannelSelectComponent.cs
@@ -20,7 +20,9 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
+using Remora.Rest.Core;
 
 namespace Remora.Discord.API.Abstractions.Objects;
 
@@ -28,6 +30,13 @@ namespace Remora.Discord.API.Abstractions.Objects;
 /// Represents a dropdown of selectable channels.
 /// </summary>
 [PublicAPI]
-public interface IChannelSelectComponent : ISelectMenuComponent
+public interface IChannelSelectComponent : ISelectMenuComponent, IPartialChannelSelectComponent
 {
+    /// <summary>
+    /// Gets the channel types to show on a <see cref="ComponentType.ChannelSelect"/> component.
+    /// </summary>
+    new Optional<IReadOnlyList<ChannelType>> ChannelTypes { get; }
+
+    /// <inheritdoc />
+    Optional<IReadOnlyList<ChannelType>> IPartialChannelSelectComponent.ChannelTypes => this.ChannelTypes;
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IChannelSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IChannelSelectComponent.cs
@@ -1,0 +1,33 @@
+//
+//  IChannelSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents a dropdown of selectable channels.
+/// </summary>
+[PublicAPI]
+public interface IChannelSelectComponent : ISelectMenuComponent
+{
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IMentionableSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IMentionableSelectComponent.cs
@@ -1,0 +1,33 @@
+//
+//  IMentionableSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents a dropdown of selectable mentionables (users and roles).
+/// </summary>
+[PublicAPI]
+public interface IMentionableSelectComponent : ISelectMenuComponent
+{
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IMentionableSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IMentionableSelectComponent.cs
@@ -28,6 +28,6 @@ namespace Remora.Discord.API.Abstractions.Objects;
 /// Represents a dropdown of selectable mentionables (users and roles).
 /// </summary>
 [PublicAPI]
-public interface IMentionableSelectComponent : ISelectMenuComponent
+public interface IMentionableSelectComponent : ISelectMenuComponent, IPartialMentionableSelectComponent
 {
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialChannelSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialChannelSelectComponent.cs
@@ -1,0 +1,33 @@
+//
+//  IPartialChannelSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents a partial dropdown of selectable channels.
+/// </summary>
+[PublicAPI]
+public interface IPartialChannelSelectComponent : IPartialSelectMenuComponent
+{
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialChannelSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialChannelSelectComponent.cs
@@ -20,7 +20,9 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
+using Remora.Rest.Core;
 
 namespace Remora.Discord.API.Abstractions.Objects;
 
@@ -30,4 +32,6 @@ namespace Remora.Discord.API.Abstractions.Objects;
 [PublicAPI]
 public interface IPartialChannelSelectComponent : IPartialSelectMenuComponent
 {
+    /// <inheritdoc cref="IChannelSelectComponent.ChannelTypes" />
+    Optional<IReadOnlyList<ChannelType>> ChannelTypes { get; }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialMentionableSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialMentionableSelectComponent.cs
@@ -1,0 +1,33 @@
+//
+//  IPartialMentionableSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents a partial dropdown of selectable mentionables (users and roles).
+/// </summary>
+[PublicAPI]
+public interface IPartialMentionableSelectComponent : IPartialSelectMenuComponent
+{
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialRoleSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialRoleSelectComponent.cs
@@ -1,0 +1,33 @@
+//
+//  IPartialRoleSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents a partial dropdown of selectable roles.
+/// </summary>
+[PublicAPI]
+public interface IPartialRoleSelectComponent : IPartialSelectMenuComponent
+{
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialSelectMenuComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialSelectMenuComponent.cs
@@ -41,6 +41,9 @@ public interface IPartialSelectMenuComponent : IPartialMessageComponent
     /// <inheritdoc cref="ISelectMenuComponent.Options"/>
     Optional<IReadOnlyList<IPartialSelectOption>> Options { get; }
 
+    /// <inheritdoc cref="ISelectMenuComponent.ChannelTypes" />
+    Optional<IReadOnlyList<ChannelType>> ChannelTypes { get; }
+
     /// <inheritdoc cref="ISelectMenuComponent.Placeholder"/>
     Optional<string> Placeholder { get; }
 

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialSelectMenuComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialSelectMenuComponent.cs
@@ -20,7 +20,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Rest.Core;
 
@@ -37,12 +36,6 @@ public interface IPartialSelectMenuComponent : IPartialMessageComponent
 
     /// <inheritdoc cref="ISelectMenuComponent.CustomID"/>
     Optional<string> CustomID { get; }
-
-    /// <inheritdoc cref="ISelectMenuComponent.Options"/>
-    Optional<IReadOnlyList<IPartialSelectOption>> Options { get; }
-
-    /// <inheritdoc cref="ISelectMenuComponent.ChannelTypes" />
-    Optional<IReadOnlyList<ChannelType>> ChannelTypes { get; }
 
     /// <inheritdoc cref="ISelectMenuComponent.Placeholder"/>
     Optional<string> Placeholder { get; }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialStringSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialStringSelectComponent.cs
@@ -20,7 +20,9 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
+using Remora.Rest.Core;
 
 namespace Remora.Discord.API.Abstractions.Objects;
 
@@ -30,4 +32,6 @@ namespace Remora.Discord.API.Abstractions.Objects;
 [PublicAPI]
 public interface IPartialStringSelectComponent : IPartialSelectMenuComponent
 {
+    /// <inheritdoc cref="IStringSelectComponent.Options" />
+    Optional<IReadOnlyList<IPartialSelectOption>> Options { get; }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialStringSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialStringSelectComponent.cs
@@ -1,0 +1,33 @@
+//
+//  IPartialStringSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents a partial dropdown of selectable strings.
+/// </summary>
+[PublicAPI]
+public interface IPartialStringSelectComponent : IPartialSelectMenuComponent
+{
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialUserSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IPartialUserSelectComponent.cs
@@ -1,0 +1,33 @@
+//
+//  IPartialUserSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents a partial dropdown of selectable users.
+/// </summary>
+[PublicAPI]
+public interface IPartialUserSelectComponent : IPartialSelectMenuComponent
+{
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IRoleSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IRoleSelectComponent.cs
@@ -28,6 +28,6 @@ namespace Remora.Discord.API.Abstractions.Objects;
 /// Represents a dropdown of selectable roles.
 /// </summary>
 [PublicAPI]
-public interface IRoleSelectComponent : ISelectMenuComponent
+public interface IRoleSelectComponent : ISelectMenuComponent, IPartialRoleSelectComponent
 {
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IRoleSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IRoleSelectComponent.cs
@@ -1,0 +1,33 @@
+//
+//  IRoleSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents a dropdown of selectable roles.
+/// </summary>
+[PublicAPI]
+public interface IRoleSelectComponent : ISelectMenuComponent
+{
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/ISelectMenuComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/ISelectMenuComponent.cs
@@ -45,7 +45,12 @@ public interface ISelectMenuComponent : IMessageComponent, IPartialSelectMenuCom
     /// <summary>
     /// Gets the options in the select menu.
     /// </summary>
-    new IReadOnlyList<ISelectOption> Options { get; }
+    new Optional<IReadOnlyList<ISelectOption>> Options { get; }
+
+    /// <summary>
+    /// Gets the channel types to show on a <see cref="ComponentType.ChannelSelect"/> component.
+    /// </summary>
+    new Optional<IReadOnlyList<ChannelType>> ChannelTypes { get; }
 
     /// <summary>
     /// Gets the placeholder text for the menu. Max 150 characters.
@@ -74,7 +79,12 @@ public interface ISelectMenuComponent : IMessageComponent, IPartialSelectMenuCom
     Optional<string> IPartialSelectMenuComponent.CustomID => this.CustomID;
 
     /// <inheritdoc/>
-    Optional<IReadOnlyList<IPartialSelectOption>> IPartialSelectMenuComponent.Options => new(this.Options);
+    Optional<IReadOnlyList<IPartialSelectOption>> IPartialSelectMenuComponent.Options => this.Options.HasValue
+        ? new Optional<IReadOnlyList<IPartialSelectOption>>(this.Options.Value)
+        : default;
+
+    /// <inheritdoc />
+    Optional<IReadOnlyList<ChannelType>> IPartialSelectMenuComponent.ChannelTypes => this.ChannelTypes;
 
     /// <inheritdoc/>
     Optional<string> IPartialSelectMenuComponent.Placeholder => this.Placeholder;

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/ISelectMenuComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/ISelectMenuComponent.cs
@@ -20,7 +20,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Rest.Core;
 

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/ISelectMenuComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/ISelectMenuComponent.cs
@@ -43,16 +43,6 @@ public interface ISelectMenuComponent : IMessageComponent, IPartialSelectMenuCom
     new string CustomID { get; }
 
     /// <summary>
-    /// Gets the options in the select menu.
-    /// </summary>
-    new Optional<IReadOnlyList<ISelectOption>> Options { get; }
-
-    /// <summary>
-    /// Gets the channel types to show on a <see cref="ComponentType.ChannelSelect"/> component.
-    /// </summary>
-    new Optional<IReadOnlyList<ChannelType>> ChannelTypes { get; }
-
-    /// <summary>
     /// Gets the placeholder text for the menu. Max 150 characters.
     /// </summary>
     new Optional<string> Placeholder { get; }
@@ -77,14 +67,6 @@ public interface ISelectMenuComponent : IMessageComponent, IPartialSelectMenuCom
 
     /// <inheritdoc/>
     Optional<string> IPartialSelectMenuComponent.CustomID => this.CustomID;
-
-    /// <inheritdoc/>
-    Optional<IReadOnlyList<IPartialSelectOption>> IPartialSelectMenuComponent.Options => this.Options.HasValue
-        ? new Optional<IReadOnlyList<IPartialSelectOption>>(this.Options.Value)
-        : default;
-
-    /// <inheritdoc />
-    Optional<IReadOnlyList<ChannelType>> IPartialSelectMenuComponent.ChannelTypes => this.ChannelTypes;
 
     /// <inheritdoc/>
     Optional<string> IPartialSelectMenuComponent.Placeholder => this.Placeholder;

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IStringSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IStringSelectComponent.cs
@@ -30,11 +30,13 @@ namespace Remora.Discord.API.Abstractions.Objects;
 /// Represents a dropdown of selectable strings.
 /// </summary>
 [PublicAPI]
-public interface IStringSelectComponent : ISelectMenuComponent
+public interface IStringSelectComponent : ISelectMenuComponent, IPartialStringSelectComponent
 {
-    /// <inheritdoc cref="ISelectMenuComponent.Options" />
+    /// <summary>
+    /// Gets the options in the select menu.
+    /// </summary>
     new IReadOnlyList<ISelectOption> Options { get; }
 
-    /// <inheritdoc/>
-    Optional<IReadOnlyList<ISelectOption>> ISelectMenuComponent.Options => new(this.Options);
+    /// <inheritdoc />
+    Optional<IReadOnlyList<IPartialSelectOption>> IPartialStringSelectComponent.Options => new(this.Options);
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IStringSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IStringSelectComponent.cs
@@ -1,0 +1,40 @@
+//
+//  IStringSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents a dropdown of selectable strings.
+/// </summary>
+[PublicAPI]
+public interface IStringSelectComponent : ISelectMenuComponent
+{
+    /// <inheritdoc cref="ISelectMenuComponent.Options" />
+    new IReadOnlyList<ISelectOption> Options { get; }
+
+    /// <inheritdoc/>
+    Optional<IReadOnlyList<ISelectOption>> ISelectMenuComponent.Options => new(this.Options);
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IUserSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IUserSelectComponent.cs
@@ -1,0 +1,33 @@
+//
+//  IUserSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents a dropdown of selectable users.
+/// </summary>
+[PublicAPI]
+public interface IUserSelectComponent : ISelectMenuComponent
+{
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IUserSelectComponent.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/Components/SelectMenu/IUserSelectComponent.cs
@@ -28,6 +28,6 @@ namespace Remora.Discord.API.Abstractions.Objects;
 /// Represents a dropdown of selectable users.
 /// </summary>
 [PublicAPI]
-public interface IUserSelectComponent : ISelectMenuComponent
+public interface IUserSelectComponent : ISelectMenuComponent, IPartialUserSelectComponent
 {
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IMessageComponentData.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IMessageComponentData.cs
@@ -43,6 +43,13 @@ public interface IMessageComponentData
     ComponentType ComponentType { get; }
 
     /// <summary>
+    /// Gets the resolved data. This may be present on, for example,
+    /// <see cref="Remora.Discord.API.Abstractions.Objects.ComponentType.UserSelect"/>
+    /// components.
+    /// </summary>
+    Optional<IApplicationCommandInteractionDataResolved> Resolved { get; }
+
+    /// <summary>
     /// Gets the values selected by the user.
     /// </summary>
     Optional<IReadOnlyList<string>> Values { get; }

--- a/Backend/Remora.Discord.API.Abstractions/Remora.Discord.API.Abstractions.csproj
+++ b/Backend/Remora.Discord.API.Abstractions/Remora.Discord.API.Abstractions.csproj
@@ -40,6 +40,36 @@
       <Compile Update="API\Objects\Activities\IActivityButton.cs">
         <DependentUpon>IActivity.cs</DependentUpon>
       </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\IStringSelectComponent.cs">
+        <DependentUpon>ISelectMenuComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\IUserSelectComponent.cs">
+        <DependentUpon>ISelectMenuComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\IRoleSelectComponent.cs">
+        <DependentUpon>ISelectMenuComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\IMentionableSelectComponent.cs">
+        <DependentUpon>ISelectMenuComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\IChannelSelectComponent.cs">
+        <DependentUpon>ISelectMenuComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\IPartialStringSelectComponent.cs">
+        <DependentUpon>IPartialSelectMenuComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\IPartialUserSelectComponent.cs">
+        <DependentUpon>IPartialSelectMenuComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\IPartialRoleSelectComponent.cs">
+        <DependentUpon>IPartialSelectMenuComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\IPartialMentionableSelectComponent.cs">
+        <DependentUpon>IPartialSelectMenuComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\IPartialChannelSelectComponent.cs">
+        <DependentUpon>IPartialSelectMenuComponent.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/ChannelSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/ChannelSelectComponent.cs
@@ -41,7 +41,4 @@ public record ChannelSelectComponent
 {
     /// <inheritdoc />
     public ComponentType Type => ComponentType.ChannelSelect;
-
-    /// <inheritdoc />
-    public Optional<IReadOnlyList<ISelectOption>> Options => default;
 }

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/ChannelSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/ChannelSelectComponent.cs
@@ -1,0 +1,47 @@
+//
+//  ChannelSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Objects;
+
+/// <inheritdoc cref="IChannelSelectComponent" />
+[PublicAPI]
+public record ChannelSelectComponent
+(
+    string CustomID,
+    Optional<IReadOnlyList<ChannelType>> ChannelTypes = default,
+    Optional<string> Placeholder = default,
+    Optional<int> MinValues = default,
+    Optional<int> MaxValues = default,
+    Optional<bool> IsDisabled = default
+) : IChannelSelectComponent
+{
+    /// <inheritdoc />
+    public ComponentType Type => ComponentType.ChannelSelect;
+
+    /// <inheritdoc />
+    public Optional<IReadOnlyList<ISelectOption>> Options => default;
+}

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/MentionableSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/MentionableSelectComponent.cs
@@ -1,5 +1,5 @@
 //
-//  SelectMenuComponent.cs
+//  MentionableSelectComponent.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -27,16 +27,23 @@ using Remora.Rest.Core;
 
 namespace Remora.Discord.API.Objects;
 
-/// <inheritdoc cref="ISelectMenuComponent" />
+/// <inheritdoc cref="IMentionableSelectComponent" />
 [PublicAPI]
-public record SelectMenuComponent
+public record MentionableSelectComponent
 (
-    ComponentType Type,
     string CustomID,
-    Optional<IReadOnlyList<ISelectOption>> Options,
-    Optional<IReadOnlyList<ChannelType>> ChannelTypes,
     Optional<string> Placeholder = default,
     Optional<int> MinValues = default,
     Optional<int> MaxValues = default,
     Optional<bool> IsDisabled = default
-) : ISelectMenuComponent;
+) : IMentionableSelectComponent
+{
+    /// <inheritdoc />
+    public ComponentType Type => ComponentType.MentionableSelect;
+
+    /// <inheritdoc />
+    public Optional<IReadOnlyList<ISelectOption>> Options => default;
+
+    /// <inheritdoc cref="ISelectMenuComponent" />
+    public Optional<IReadOnlyList<ChannelType>> ChannelTypes => default;
+}

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/MentionableSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/MentionableSelectComponent.cs
@@ -20,7 +20,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Rest.Core;
@@ -40,10 +39,4 @@ public record MentionableSelectComponent
 {
     /// <inheritdoc />
     public ComponentType Type => ComponentType.MentionableSelect;
-
-    /// <inheritdoc />
-    public Optional<IReadOnlyList<ISelectOption>> Options => default;
-
-    /// <inheritdoc cref="ISelectMenuComponent" />
-    public Optional<IReadOnlyList<ChannelType>> ChannelTypes => default;
 }

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialChannelSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialChannelSelectComponent.cs
@@ -32,7 +32,6 @@ namespace Remora.Discord.API.Objects;
 public record PartialChannelSelectComponent
 (
     Optional<string> CustomID,
-    Optional<IReadOnlyList<IPartialSelectOption>> Options = default,
     Optional<IReadOnlyList<ChannelType>> ChannelTypes = default,
     Optional<string> Placeholder = default,
     Optional<int> MinValues = default,

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialChannelSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialChannelSelectComponent.cs
@@ -1,0 +1,45 @@
+//
+//  PartialChannelSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Objects;
+
+/// <inheritdoc cref="IPartialChannelSelectComponent" />
+[PublicAPI]
+public record PartialChannelSelectComponent
+(
+    Optional<string> CustomID,
+    Optional<IReadOnlyList<IPartialSelectOption>> Options = default,
+    Optional<IReadOnlyList<ChannelType>> ChannelTypes = default,
+    Optional<string> Placeholder = default,
+    Optional<int> MinValues = default,
+    Optional<int> MaxValues = default,
+    Optional<bool> IsDisabled = default
+) : IPartialChannelSelectComponent
+{
+    /// <inheritdoc />
+    public Optional<ComponentType> Type => ComponentType.ChannelSelect;
+}

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialMentionableSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialMentionableSelectComponent.cs
@@ -20,7 +20,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Rest.Core;
@@ -32,8 +31,6 @@ namespace Remora.Discord.API.Objects;
 public record PartialMentionableSelectComponent
 (
     Optional<string> CustomID,
-    Optional<IReadOnlyList<IPartialSelectOption>> Options = default,
-    Optional<IReadOnlyList<ChannelType>> ChannelTypes = default,
     Optional<string> Placeholder = default,
     Optional<int> MinValues = default,
     Optional<int> MaxValues = default,

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialMentionableSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialMentionableSelectComponent.cs
@@ -1,0 +1,45 @@
+//
+//  PartialMentionableSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Objects;
+
+/// <inheritdoc cref="IPartialMentionableSelectComponent" />
+[PublicAPI]
+public record PartialMentionableSelectComponent
+(
+    Optional<string> CustomID,
+    Optional<IReadOnlyList<IPartialSelectOption>> Options = default,
+    Optional<IReadOnlyList<ChannelType>> ChannelTypes = default,
+    Optional<string> Placeholder = default,
+    Optional<int> MinValues = default,
+    Optional<int> MaxValues = default,
+    Optional<bool> IsDisabled = default
+) : IPartialMentionableSelectComponent
+{
+    /// <inheritdoc />
+    public Optional<ComponentType> Type => ComponentType.MentionableSelect;
+}

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialRoleSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialRoleSelectComponent.cs
@@ -20,7 +20,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Rest.Core;
@@ -32,8 +31,6 @@ namespace Remora.Discord.API.Objects;
 public record PartialRoleSelectComponent
 (
     Optional<string> CustomID,
-    Optional<IReadOnlyList<IPartialSelectOption>> Options = default,
-    Optional<IReadOnlyList<ChannelType>> ChannelTypes = default,
     Optional<string> Placeholder = default,
     Optional<int> MinValues = default,
     Optional<int> MaxValues = default,

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialRoleSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialRoleSelectComponent.cs
@@ -1,5 +1,5 @@
 //
-//  PartialSelectMenuComponent.cs
+//  PartialRoleSelectComponent.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -27,16 +27,19 @@ using Remora.Rest.Core;
 
 namespace Remora.Discord.API.Objects;
 
-/// <inheritdoc cref="IPartialSelectMenuComponent" />
+/// <inheritdoc cref="IPartialRoleSelectComponent" />
 [PublicAPI]
-public record PartialSelectMenuComponent
+public record PartialRoleSelectComponent
 (
-    Optional<ComponentType> Type,
     Optional<string> CustomID,
-    Optional<IReadOnlyList<IPartialSelectOption>> Options,
-    Optional<IReadOnlyList<ChannelType>> ChannelTypes,
+    Optional<IReadOnlyList<IPartialSelectOption>> Options = default,
+    Optional<IReadOnlyList<ChannelType>> ChannelTypes = default,
     Optional<string> Placeholder = default,
     Optional<int> MinValues = default,
     Optional<int> MaxValues = default,
     Optional<bool> IsDisabled = default
-) : IPartialSelectMenuComponent;
+) : IPartialRoleSelectComponent
+{
+    /// <inheritdoc />
+    public Optional<ComponentType> Type => ComponentType.RoleSelect;
+}

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialSelectMenuComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialSelectMenuComponent.cs
@@ -31,14 +31,12 @@ namespace Remora.Discord.API.Objects;
 [PublicAPI]
 public record PartialSelectMenuComponent
 (
+    Optional<ComponentType> Type,
     Optional<string> CustomID,
     Optional<IReadOnlyList<IPartialSelectOption>> Options,
+    Optional<IReadOnlyList<ChannelType>> ChannelTypes,
     Optional<string> Placeholder = default,
     Optional<int> MinValues = default,
     Optional<int> MaxValues = default,
     Optional<bool> IsDisabled = default
-) : IPartialSelectMenuComponent
-{
-    /// <inheritdoc />
-    public Optional<ComponentType> Type => ComponentType.SelectMenu;
-}
+) : IPartialSelectMenuComponent;

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialStringSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialStringSelectComponent.cs
@@ -33,7 +33,6 @@ public record PartialStringSelectComponent
 (
     Optional<string> CustomID,
     Optional<IReadOnlyList<IPartialSelectOption>> Options = default,
-    Optional<IReadOnlyList<ChannelType>> ChannelTypes = default,
     Optional<string> Placeholder = default,
     Optional<int> MinValues = default,
     Optional<int> MaxValues = default,

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialStringSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialStringSelectComponent.cs
@@ -1,0 +1,45 @@
+//
+//  PartialStringSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Objects;
+
+/// <inheritdoc cref="IPartialStringSelectComponent" />
+[PublicAPI]
+public record PartialStringSelectComponent
+(
+    Optional<string> CustomID,
+    Optional<IReadOnlyList<IPartialSelectOption>> Options = default,
+    Optional<IReadOnlyList<ChannelType>> ChannelTypes = default,
+    Optional<string> Placeholder = default,
+    Optional<int> MinValues = default,
+    Optional<int> MaxValues = default,
+    Optional<bool> IsDisabled = default
+) : IPartialStringSelectComponent
+{
+    /// <inheritdoc />
+    public Optional<ComponentType> Type => ComponentType.StringSelect;
+}

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialUserSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialUserSelectComponent.cs
@@ -20,7 +20,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Rest.Core;
@@ -32,8 +31,6 @@ namespace Remora.Discord.API.Objects;
 public record PartialUserSelectComponent
 (
     Optional<string> CustomID,
-    Optional<IReadOnlyList<IPartialSelectOption>> Options = default,
-    Optional<IReadOnlyList<ChannelType>> ChannelTypes = default,
     Optional<string> Placeholder = default,
     Optional<int> MinValues = default,
     Optional<int> MaxValues = default,

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialUserSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/PartialUserSelectComponent.cs
@@ -1,0 +1,45 @@
+//
+//  PartialUserSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Objects;
+
+/// <inheritdoc cref="IPartialUserSelectComponent" />
+[PublicAPI]
+public record PartialUserSelectComponent
+(
+    Optional<string> CustomID,
+    Optional<IReadOnlyList<IPartialSelectOption>> Options = default,
+    Optional<IReadOnlyList<ChannelType>> ChannelTypes = default,
+    Optional<string> Placeholder = default,
+    Optional<int> MinValues = default,
+    Optional<int> MaxValues = default,
+    Optional<bool> IsDisabled = default
+) : IPartialUserSelectComponent
+{
+    /// <inheritdoc />
+    public Optional<ComponentType> Type => ComponentType.UserSelect;
+}

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/RoleSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/RoleSelectComponent.cs
@@ -1,0 +1,49 @@
+//
+//  RoleSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Objects;
+
+/// <inheritdoc cref="IRoleSelectComponent" />
+[PublicAPI]
+public record RoleSelectComponent
+(
+    string CustomID,
+    Optional<string> Placeholder = default,
+    Optional<int> MinValues = default,
+    Optional<int> MaxValues = default,
+    Optional<bool> IsDisabled = default
+) : IRoleSelectComponent
+{
+    /// <inheritdoc />
+    public ComponentType Type => ComponentType.RoleSelect;
+
+    /// <inheritdoc />
+    public Optional<IReadOnlyList<ISelectOption>> Options => default;
+
+    /// <inheritdoc cref="ISelectMenuComponent" />
+    public Optional<IReadOnlyList<ChannelType>> ChannelTypes => default;
+}

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/RoleSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/RoleSelectComponent.cs
@@ -20,7 +20,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Rest.Core;
@@ -40,10 +39,4 @@ public record RoleSelectComponent
 {
     /// <inheritdoc />
     public ComponentType Type => ComponentType.RoleSelect;
-
-    /// <inheritdoc />
-    public Optional<IReadOnlyList<ISelectOption>> Options => default;
-
-    /// <inheritdoc cref="ISelectMenuComponent" />
-    public Optional<IReadOnlyList<ChannelType>> ChannelTypes => default;
 }

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/SelectMenuComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/SelectMenuComponent.cs
@@ -31,14 +31,12 @@ namespace Remora.Discord.API.Objects;
 [PublicAPI]
 public record SelectMenuComponent
 (
+    ComponentType Type,
     string CustomID,
-    IReadOnlyList<ISelectOption> Options,
+    Optional<IReadOnlyList<ISelectOption>> Options,
+    Optional<IReadOnlyList<ChannelType>> ChannelTypes,
     Optional<string> Placeholder = default,
     Optional<int> MinValues = default,
     Optional<int> MaxValues = default,
     Optional<bool> IsDisabled = default
-) : ISelectMenuComponent
-{
-    /// <inheritdoc />
-    public ComponentType Type => ComponentType.SelectMenu;
-}
+) : ISelectMenuComponent;

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/StringSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/StringSelectComponent.cs
@@ -1,0 +1,47 @@
+//
+//  StringSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Objects;
+
+/// <inheritdoc cref="IStringSelectComponent" />
+[PublicAPI]
+public record StringSelectComponent
+(
+    string CustomID,
+    IReadOnlyList<ISelectOption> Options,
+    Optional<string> Placeholder = default,
+    Optional<int> MinValues = default,
+    Optional<int> MaxValues = default,
+    Optional<bool> IsDisabled = default
+) : IStringSelectComponent
+{
+    /// <inheritdoc />
+    public ComponentType Type => ComponentType.StringSelect;
+
+    /// <inheritdoc cref="ISelectMenuComponent" />
+    public Optional<IReadOnlyList<ChannelType>> ChannelTypes => default;
+}

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/StringSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/StringSelectComponent.cs
@@ -41,7 +41,4 @@ public record StringSelectComponent
 {
     /// <inheritdoc />
     public ComponentType Type => ComponentType.StringSelect;
-
-    /// <inheritdoc cref="ISelectMenuComponent" />
-    public Optional<IReadOnlyList<ChannelType>> ChannelTypes => default;
 }

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/UserSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/UserSelectComponent.cs
@@ -1,0 +1,49 @@
+//
+//  UserSelectComponent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Objects;
+
+/// <inheritdoc cref="IUserSelectComponent" />
+[PublicAPI]
+public record UserSelectComponent
+(
+    string CustomID,
+    Optional<string> Placeholder = default,
+    Optional<int> MinValues = default,
+    Optional<int> MaxValues = default,
+    Optional<bool> IsDisabled = default
+) : IUserSelectComponent
+{
+    /// <inheritdoc />
+    public ComponentType Type => ComponentType.UserSelect;
+
+    /// <inheritdoc />
+    public Optional<IReadOnlyList<ISelectOption>> Options => default;
+
+    /// <inheritdoc cref="ISelectMenuComponent" />
+    public Optional<IReadOnlyList<ChannelType>> ChannelTypes => default;
+}

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/UserSelectComponent.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/Components/SelectMenu/UserSelectComponent.cs
@@ -20,7 +20,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Rest.Core;
@@ -40,10 +39,4 @@ public record UserSelectComponent
 {
     /// <inheritdoc />
     public ComponentType Type => ComponentType.UserSelect;
-
-    /// <inheritdoc />
-    public Optional<IReadOnlyList<ISelectOption>> Options => default;
-
-    /// <inheritdoc cref="ISelectMenuComponent" />
-    public Optional<IReadOnlyList<ChannelType>> ChannelTypes => default;
 }

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/MessageComponentData.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/MessageComponentData.cs
@@ -33,5 +33,6 @@ public record MessageComponentData
 (
     string CustomID,
     ComponentType ComponentType,
+    Optional<IApplicationCommandInteractionDataResolved> Resolved,
     Optional<IReadOnlyList<string>> Values
 ) : IMessageComponentData;

--- a/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
@@ -968,10 +968,34 @@ public static class ServiceCollectionExtensions
             .IncludeWhenSerializing(c => c.Type)
             .WithPropertyName(c => c.IsDisabled, "disabled");
 
-        options.AddDataObjectConverter<ISelectMenuComponent, SelectMenuComponent>()
+        options.AddDataObjectConverter<IStringSelectComponent, StringSelectComponent>()
             .IncludeWhenSerializing(c => c.Type)
             .WithPropertyName(c => c.IsDisabled, "disabled");
-        options.AddDataObjectConverter<IPartialSelectMenuComponent, PartialSelectMenuComponent>()
+        options.AddDataObjectConverter<IUserSelectComponent, UserSelectComponent>()
+            .IncludeWhenSerializing(c => c.Type)
+            .WithPropertyName(c => c.IsDisabled, "disabled");
+        options.AddDataObjectConverter<IRoleSelectComponent, RoleSelectComponent>()
+            .IncludeWhenSerializing(c => c.Type)
+            .WithPropertyName(c => c.IsDisabled, "disabled");
+        options.AddDataObjectConverter<IMentionableSelectComponent, MentionableSelectComponent>()
+            .IncludeWhenSerializing(c => c.Type)
+            .WithPropertyName(c => c.IsDisabled, "disabled");
+        options.AddDataObjectConverter<IChannelSelectComponent, ChannelSelectComponent>()
+            .IncludeWhenSerializing(c => c.Type)
+            .WithPropertyName(c => c.IsDisabled, "disabled");
+        options.AddDataObjectConverter<IPartialStringSelectComponent, PartialStringSelectComponent>()
+            .IncludeWhenSerializing(c => c.Type)
+            .WithPropertyName(c => c.IsDisabled, "disabled");
+        options.AddDataObjectConverter<IPartialUserSelectComponent, PartialUserSelectComponent>()
+            .IncludeWhenSerializing(c => c.Type)
+            .WithPropertyName(c => c.IsDisabled, "disabled");
+        options.AddDataObjectConverter<IPartialRoleSelectComponent, PartialRoleSelectComponent>()
+            .IncludeWhenSerializing(c => c.Type)
+            .WithPropertyName(c => c.IsDisabled, "disabled");
+        options.AddDataObjectConverter<IPartialMentionableSelectComponent, PartialMentionableSelectComponent>()
+            .IncludeWhenSerializing(c => c.Type)
+            .WithPropertyName(c => c.IsDisabled, "disabled");
+        options.AddDataObjectConverter<IPartialChannelSelectComponent, PartialChannelSelectComponent>()
             .IncludeWhenSerializing(c => c.Type)
             .WithPropertyName(c => c.IsDisabled, "disabled");
 

--- a/Backend/Remora.Discord.API/Json/Converters/Internal/MessageComponentConverter.cs
+++ b/Backend/Remora.Discord.API/Json/Converters/Internal/MessageComponentConverter.cs
@@ -68,7 +68,11 @@ internal class MessageComponentConverter : JsonConverter<IMessageComponent>
                 => JsonSerializer.Deserialize<IActionRowComponent>(document.RootElement.GetRawText(), options),
             ComponentType.Button
                 => JsonSerializer.Deserialize<IButtonComponent>(document.RootElement.GetRawText(), options),
-            ComponentType.SelectMenu
+            ComponentType.StringSelect
+                or ComponentType.UserSelect
+                or ComponentType.RoleSelect
+                or ComponentType.MentionableSelect
+                or ComponentType.ChannelSelect
                 => JsonSerializer.Deserialize<ISelectMenuComponent>(document.RootElement.GetRawText(), options),
             ComponentType.TextInput
                 => JsonSerializer.Deserialize<ITextInputComponent>(document.RootElement.GetRawText(), options),

--- a/Backend/Remora.Discord.API/Json/Converters/Internal/MessageComponentConverter.cs
+++ b/Backend/Remora.Discord.API/Json/Converters/Internal/MessageComponentConverter.cs
@@ -69,13 +69,17 @@ internal class MessageComponentConverter : JsonConverter<IMessageComponent>
             ComponentType.Button
                 => JsonSerializer.Deserialize<IButtonComponent>(document.RootElement.GetRawText(), options),
             ComponentType.StringSelect
-                or ComponentType.UserSelect
-                or ComponentType.RoleSelect
-                or ComponentType.MentionableSelect
-                or ComponentType.ChannelSelect
-                => JsonSerializer.Deserialize<ISelectMenuComponent>(document.RootElement.GetRawText(), options),
+                => document.RootElement.Deserialize<IStringSelectComponent>(options),
             ComponentType.TextInput
                 => JsonSerializer.Deserialize<ITextInputComponent>(document.RootElement.GetRawText(), options),
+            ComponentType.UserSelect
+                => document.RootElement.Deserialize<IUserSelectComponent>(options),
+            ComponentType.RoleSelect
+                => document.RootElement.Deserialize<IRoleSelectComponent>(options),
+            ComponentType.MentionableSelect
+                => document.RootElement.Deserialize<IMentionableSelectComponent>(options),
+            ComponentType.ChannelSelect
+                => document.RootElement.Deserialize<IChannelSelectComponent>(options),
             _ => throw new ArgumentOutOfRangeException(nameof(type))
         };
     }
@@ -95,14 +99,34 @@ internal class MessageComponentConverter : JsonConverter<IMessageComponent>
                 JsonSerializer.Serialize(writer, button, options);
                 break;
             }
-            case ISelectMenuComponent selectMenu:
+            case IStringSelectComponent stringSelect:
             {
-                JsonSerializer.Serialize(writer, selectMenu, options);
+                JsonSerializer.Serialize(writer, stringSelect, options);
                 break;
             }
             case ITextInputComponent textInput:
             {
                 JsonSerializer.Serialize(writer, textInput, options);
+                break;
+            }
+            case IUserSelectComponent userSelect:
+            {
+                JsonSerializer.Serialize(writer, userSelect, options);
+                break;
+            }
+            case IRoleSelectComponent roleSelect:
+            {
+                JsonSerializer.Serialize(writer, roleSelect, options);
+                break;
+            }
+            case IMentionableSelectComponent mentionableSelect:
+            {
+                JsonSerializer.Serialize(writer, mentionableSelect, options);
+                break;
+            }
+            case IChannelSelectComponent channelSelect:
+            {
+                JsonSerializer.Serialize(writer, channelSelect, options);
                 break;
             }
             default:

--- a/Backend/Remora.Discord.API/Json/Converters/Internal/PartialMessageComponentConverter.cs
+++ b/Backend/Remora.Discord.API/Json/Converters/Internal/PartialMessageComponentConverter.cs
@@ -68,7 +68,11 @@ internal class PartialMessageComponentConverter : JsonConverter<IPartialMessageC
                 => JsonSerializer.Deserialize<IPartialActionRowComponent>(document.RootElement.GetRawText(), options),
             ComponentType.Button
                 => JsonSerializer.Deserialize<IButtonComponent>(document.RootElement.GetRawText(), options),
-            ComponentType.SelectMenu
+            ComponentType.StringSelect
+                or ComponentType.UserSelect
+                or ComponentType.RoleSelect
+                or ComponentType.MentionableSelect
+                or ComponentType.ChannelSelect
                 => JsonSerializer.Deserialize<ISelectMenuComponent>(document.RootElement.GetRawText(), options),
             ComponentType.TextInput
                 => JsonSerializer.Deserialize<IPartialTextInputComponent>(document.RootElement.GetRawText(), options),

--- a/Backend/Remora.Discord.API/Json/Converters/Internal/PartialMessageComponentConverter.cs
+++ b/Backend/Remora.Discord.API/Json/Converters/Internal/PartialMessageComponentConverter.cs
@@ -67,15 +67,19 @@ internal class PartialMessageComponentConverter : JsonConverter<IPartialMessageC
             ComponentType.ActionRow
                 => JsonSerializer.Deserialize<IPartialActionRowComponent>(document.RootElement.GetRawText(), options),
             ComponentType.Button
-                => JsonSerializer.Deserialize<IButtonComponent>(document.RootElement.GetRawText(), options),
+                => JsonSerializer.Deserialize<IPartialButtonComponent>(document.RootElement.GetRawText(), options),
             ComponentType.StringSelect
-                or ComponentType.UserSelect
-                or ComponentType.RoleSelect
-                or ComponentType.MentionableSelect
-                or ComponentType.ChannelSelect
-                => JsonSerializer.Deserialize<ISelectMenuComponent>(document.RootElement.GetRawText(), options),
+                => document.RootElement.Deserialize<IPartialStringSelectComponent>(options),
             ComponentType.TextInput
                 => JsonSerializer.Deserialize<IPartialTextInputComponent>(document.RootElement.GetRawText(), options),
+            ComponentType.UserSelect
+                => document.RootElement.Deserialize<IPartialUserSelectComponent>(options),
+            ComponentType.RoleSelect
+                => document.RootElement.Deserialize<IPartialRoleSelectComponent>(options),
+            ComponentType.MentionableSelect
+                => document.RootElement.Deserialize<IPartialMentionableSelectComponent>(options),
+            ComponentType.ChannelSelect
+                => document.RootElement.Deserialize<IPartialChannelSelectComponent>(options),
             _ => throw new ArgumentOutOfRangeException(nameof(type))
         };
     }
@@ -95,14 +99,34 @@ internal class PartialMessageComponentConverter : JsonConverter<IPartialMessageC
                 JsonSerializer.Serialize(writer, button, options);
                 break;
             }
-            case IPartialSelectMenuComponent selectMenu:
+            case IPartialStringSelectComponent stringSelect:
             {
-                JsonSerializer.Serialize(writer, selectMenu, options);
+                JsonSerializer.Serialize(writer, stringSelect, options);
                 break;
             }
             case IPartialTextInputComponent textInput:
             {
                 JsonSerializer.Serialize(writer, textInput, options);
+                break;
+            }
+            case IPartialUserSelectComponent userSelect:
+            {
+                JsonSerializer.Serialize(writer, userSelect, options);
+                break;
+            }
+            case IPartialRoleSelectComponent roleSelect:
+            {
+                JsonSerializer.Serialize(writer, roleSelect, options);
+                break;
+            }
+            case IPartialMentionableSelectComponent mentionableSelect:
+            {
+                JsonSerializer.Serialize(writer, mentionableSelect, options);
+                break;
+            }
+            case IPartialChannelSelectComponent channelSelect:
+            {
+                JsonSerializer.Serialize(writer, channelSelect, options);
                 break;
             }
             default:

--- a/Backend/Remora.Discord.API/Remora.Discord.API.csproj
+++ b/Backend/Remora.Discord.API/Remora.Discord.API.csproj
@@ -66,11 +66,23 @@
       <Compile Update="API\Objects\Interactions\Components\SelectMenu\PartialSelectOption.cs">
         <DependentUpon>SelectOption.cs</DependentUpon>
       </Compile>
-      <Compile Update="API\Objects\Interactions\Components\SelectMenu\PartialSelectMenuComponent.cs">
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\PartialStringSelectComponent.cs">
         <DependentUpon>SelectMenuComponent.cs</DependentUpon>
       </Compile>
       <Compile Update="API\Objects\Interactions\Components\TextInput\PartialTextInputComponent.cs">
         <DependentUpon>TextInputComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\PartialChannelSelectComponent.cs">
+        <DependentUpon>ChannelSelectComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\PartialUserSelectComponent.cs">
+        <DependentUpon>UserSelectComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\PartialMentionableSelectComponent.cs">
+        <DependentUpon>MentionableSelectComponent.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\Objects\Interactions\Components\SelectMenu\PartialRoleSelectComponent.cs">
+        <DependentUpon>RoleSelectComponent.cs</DependentUpon>
       </Compile>
     </ItemGroup>
 

--- a/Backend/Remora.Discord.API/Remora.Discord.API.csproj
+++ b/Backend/Remora.Discord.API/Remora.Discord.API.csproj
@@ -67,7 +67,7 @@
         <DependentUpon>SelectOption.cs</DependentUpon>
       </Compile>
       <Compile Update="API\Objects\Interactions\Components\SelectMenu\PartialStringSelectComponent.cs">
-        <DependentUpon>SelectMenuComponent.cs</DependentUpon>
+        <DependentUpon>StringSelectComponent.cs</DependentUpon>
       </Compile>
       <Compile Update="API\Objects\Interactions\Components\TextInput\PartialTextInputComponent.cs">
         <DependentUpon>TextInputComponent.cs</DependentUpon>

--- a/Remora.Discord.Interactivity/CustomIDHelpers.cs
+++ b/Remora.Discord.Interactivity/CustomIDHelpers.cs
@@ -35,6 +35,12 @@ namespace Remora.Discord.Interactivity;
 public static class CustomIDHelpers
 {
     /// <summary>
+    /// Gets the name used to build IDs for select menu components.
+    /// This may include text, role, channel etc. select menus.
+    /// </summary>
+    private const string SelectComponentName = "select-menu";
+
+    /// <summary>
     /// Creates an ID string that can be used with button components.
     /// </summary>
     /// <param name="name">
@@ -66,7 +72,7 @@ public static class CustomIDHelpers
     /// </param>
     /// <returns>The custom ID.</returns>
     public static string CreateSelectMenuID(string name)
-        => CreateID(name, ComponentType.SelectMenu);
+        => FormatID(SelectComponentName, name, Array.Empty<string>());
 
     /// <summary>
     /// Creates an ID string that can be used with select menu components.
@@ -80,7 +86,7 @@ public static class CustomIDHelpers
     /// </param>
     /// <returns>The custom ID.</returns>
     public static string CreateSelectMenuID(string name, params string[] path)
-        => CreateID(ComponentType.SelectMenu, name, path);
+        => FormatID(SelectComponentName, name, path);
 
     /// <summary>
     /// Creates an ID string that can be used with modals.

--- a/Remora.Discord.Interactivity/README.md
+++ b/Remora.Discord.Interactivity/README.md
@@ -104,10 +104,10 @@ interaction response. Remora will handle this all for you automatically, with th
 expectation that you name your command parameters `users`, `roles` and `channels`
 respectively.
 
-Please note that resolved data only returns _partial_ objects. By using a non-partial
-interface on a command parameter (e.g. `IReadOnlyList<IChannel>` rather than
-`IReadOnlyList<IPartialChannel>`), you may incur additional network calls if the values
-required for that parameter are not already cached.
+Please note that resolved data will contain _partial_ objects for channels, although resolved
+users and roles are concrete. Hence, by using a non-partial interface on a channel command
+parameter (e.g. `IReadOnlyList<IChannel>` rather than `IReadOnlyList<IPartialChannel>`),
+you may incur additional network calls if the concrete channel objects are not already cached.
 
 ```c#
 [SelectMenu("my-channel-select-menu")]

--- a/Remora.Discord.Interactivity/README.md
+++ b/Remora.Discord.Interactivity/README.md
@@ -95,6 +95,31 @@ public Task<Result> OnMenuSelectionAsync(IReadOnlyList<MyArbitraryType> values)
 The raw values in question are taken from the select menu options of the 
 component, and can be any parseable data.
 
+You can take advantage of this when using `user`, `role`, or `channel` select menus, as the values
+returned will be the ID of the selected user, role or channel. However, it is better to instead
+use the resolved data when possible, to prevent possible extra API calls. This is also more reliable
+when using `mentionable` menus, as the values returned do not differentiate between user and role IDs.
+
+```c#
+private readonly InteractionContext _context; // Injected
+
+[SelectMenu("my-mentionable-menu")]
+public Task<Result> OnMenuSelectionAsync(IReadOnlyList<string> values)
+{
+    // `values` will contain the IDs of the selected users/roles
+
+    if (!_context.Data.TryPickT1(out var components, out _))
+        // error, expected message component data to be present
+
+    if (!components.Resolved.IsDefined(out var resolvedData))
+        // error, expected resolved data to be present on non-string select menus
+
+    resolvedData.Users.IsDefined(...);
+    resolvedData.Members.IsDefined(...);
+    resolvedData.Roles.IsDefined(...);
+}
+```
+
 ### Modals
 Modals are functions with zero or more parameters matching the value types of 
 the modal's contained components. This might sound a little complex, but is in

--- a/Remora.Discord.Interactivity/README.md
+++ b/Remora.Discord.Interactivity/README.md
@@ -49,9 +49,12 @@ public Task<Result> OnButtonPressedAsync()
 
 ### Select Menus
 Select menus are functions with a list of objects as its sole parameter, 
-decorated with the `SelectMenu` attribute. The parameter *must* be named 
-`values`, and will contain zero or more values selected by the end user in the 
-menu.
+decorated with the `SelectMenu` attribute. There are multiple types of
+select menu, namely _string_, _user_, _role_, _mentionable_ (users AND roles),
+and _channel_ select menus. 
+
+When using a `string` select menu, the command parameter *must* be named
+`values`, and will contain zero or more values selected by the end user in the menu.
 
 You can control the number of allowed values when creating the component through
 its `MinValues` and `MaxValues` properties.
@@ -95,15 +98,25 @@ public Task<Result> OnMenuSelectionAsync(IReadOnlyList<MyArbitraryType> values)
 The raw values in question are taken from the select menu options of the 
 component, and can be any parseable data.
 
-When using `user`, `role`, `mentionable` and `channel` select menus, no values are returned.
-Instead, you should use the resolved data to retrieve the user's selections.
-For example, to retrieve data from a `MentionableSelect` interaction response:
+When using `user`, `role`, `mentionable` and `channel` select menus, no values are
+returned and the selected values are instead sent as resolved objects on the
+interaction response. Remora will handle this all for you automatically, with the
+expectation that you name your command parameters `users`, `roles` and `channels`
+respectively.
+
+```c#
+[SelectMenu("my-channel-select-menu")]
+public Task<Result> OnMenuSelectionAsync(IReadOnlyList<IChannel> channels)
+{
+    // ...
+}
+```
 
 ```c#
 private readonly InteractionContext _context; // Injected
 
 [SelectMenu("my-mentionable-menu")]
-public Task<Result> OnMenuSelectionAsync(IReadOnlyList<string> values)
+public Task<Result> OnMenuSelectionAsync(IReadOnlyList<IChannel> channels)
 {
     // `values` will contain the IDs of the selected users/roles
 

--- a/Remora.Discord.Interactivity/README.md
+++ b/Remora.Discord.Interactivity/README.md
@@ -104,6 +104,11 @@ interaction response. Remora will handle this all for you automatically, with th
 expectation that you name your command parameters `users`, `roles` and `channels`
 respectively.
 
+Please note that resolved data only returns _partial_ objects. By using a non-partial
+interface on a command parameter (e.g. `IReadOnlyList<IChannel>` rather than
+`IReadOnlyList<IPartialChannel>`), you may incur additional network calls if the values
+required for that parameter are not already cached.
+
 ```c#
 [SelectMenu("my-channel-select-menu")]
 public Task<Result> OnMenuSelectionAsync(IReadOnlyList<IChannel> channels)

--- a/Remora.Discord.Interactivity/README.md
+++ b/Remora.Discord.Interactivity/README.md
@@ -95,10 +95,9 @@ public Task<Result> OnMenuSelectionAsync(IReadOnlyList<MyArbitraryType> values)
 The raw values in question are taken from the select menu options of the 
 component, and can be any parseable data.
 
-You can take advantage of this when using `user`, `role`, or `channel` select menus, as the values
-returned will be the ID of the selected user, role or channel. However, it is better to instead
-use the resolved data when possible, to prevent possible extra API calls. This is also more reliable
-when using `mentionable` menus, as the values returned do not differentiate between user and role IDs.
+When using `user`, `role`, `mentionable` and `channel` select menus, no values are returned.
+Instead, you should use the resolved data to retrieve the user's selections.
+For example, to retrieve data from a `MentionableSelect` interaction response:
 
 ```c#
 private readonly InteractionContext _context; // Injected

--- a/Remora.Discord.Interactivity/Responders/InteractivityResponder.cs
+++ b/Remora.Discord.Interactivity/Responders/InteractivityResponder.cs
@@ -155,7 +155,7 @@ internal sealed class InteractivityResponder : IResponder<IInteractionCreate>
                 or ComponentType.RoleSelect
                 or ComponentType.MentionableSelect
                 or ComponentType.ChannelSelect
-                => new Dictionary<string, IReadOnlyList<string>>(),
+                => BuildParametersFromResolvedData(data),
             _ => new InvalidOperationError("An unsupported component type was encountered.")
         };
 
@@ -167,6 +167,48 @@ internal sealed class InteractivityResponder : IResponder<IInteractionCreate>
         var parameters = buildParameters.Entity;
 
         return await TryExecuteInteractionCommandAsync(context, commandPath, parameters, ct);
+    }
+
+    private static Result<IReadOnlyDictionary<string, IReadOnlyList<string>>> BuildParametersFromResolvedData
+    (
+        IMessageComponentData data
+    )
+    {
+        var parameters = new Dictionary<string, IReadOnlyList<string>>();
+
+        if (!data.Resolved.IsDefined(out var resolved))
+        {
+            return parameters;
+        }
+
+        if (resolved.Users.IsDefined(out var users))
+        {
+            parameters.Add
+            (
+                "users",
+                users.Keys.Select(x => x.ToString()).ToList()
+            );
+        }
+
+        if (resolved.Roles.IsDefined(out var roles))
+        {
+            parameters.Add
+            (
+                "roles",
+                roles.Keys.Select(x => x.ToString()).ToList()
+            );
+        }
+
+        if (resolved.Channels.IsDefined(out var channels))
+        {
+            parameters.Add
+            (
+                "channels",
+                channels.Keys.Select(x => x.ToString()).ToList()
+            );
+        }
+
+        return parameters;
     }
 
     private async Task<Result> HandleModalInteractionAsync

--- a/Remora.Discord.Interactivity/Responders/InteractivityResponder.cs
+++ b/Remora.Discord.Interactivity/Responders/InteractivityResponder.cs
@@ -144,18 +144,18 @@ internal sealed class InteractivityResponder : IResponder<IInteractionCreate>
         var buildParameters = data.ComponentType switch
         {
             ComponentType.Button => new Dictionary<string, IReadOnlyList<string>>(),
-            ComponentType.StringSelect
-                or ComponentType.UserSelect
+            ComponentType.StringSelect => Result<IReadOnlyDictionary<string, IReadOnlyList<string>>>.FromSuccess
+            (
+                new Dictionary<string, IReadOnlyList<string>>
+                {
+                    { "values", data.Values.Value }
+                }
+            ),
+            ComponentType.UserSelect
                 or ComponentType.RoleSelect
                 or ComponentType.MentionableSelect
                 or ComponentType.ChannelSelect
-                => Result<IReadOnlyDictionary<string, IReadOnlyList<string>>>.FromSuccess
-                (
-                    new Dictionary<string, IReadOnlyList<string>>
-                    {
-                        { "values", data.Values.Value }
-                    }
-                ),
+                => new Dictionary<string, IReadOnlyList<string>>(),
             _ => new InvalidOperationError("An unsupported component type was encountered.")
         };
 

--- a/Remora.Discord.Interactivity/Responders/InteractivityResponder.cs
+++ b/Remora.Discord.Interactivity/Responders/InteractivityResponder.cs
@@ -279,7 +279,7 @@ internal sealed class InteractivityResponder : IResponder<IInteractionCreate>
                     parameters.Add(id.Replace('-', '_').Camelize(), new[] { value });
                     break;
                 }
-                case IPartialSelectMenuComponent selectMenu:
+                case IPartialStringSelectComponent selectMenu:
                 {
                     if (!selectMenu.CustomID.IsDefined(out var id))
                     {

--- a/Remora.Discord.Interactivity/Responders/InteractivityResponder.cs
+++ b/Remora.Discord.Interactivity/Responders/InteractivityResponder.cs
@@ -130,7 +130,7 @@ internal sealed class InteractivityResponder : IResponder<IInteractionCreate>
             return Result.FromSuccess();
         }
 
-        if (data.ComponentType is ComponentType.SelectMenu)
+        if (data.ComponentType is ComponentType.StringSelect)
         {
             if (!data.Values.HasValue)
             {
@@ -144,13 +144,18 @@ internal sealed class InteractivityResponder : IResponder<IInteractionCreate>
         var buildParameters = data.ComponentType switch
         {
             ComponentType.Button => new Dictionary<string, IReadOnlyList<string>>(),
-            ComponentType.SelectMenu => Result<IReadOnlyDictionary<string, IReadOnlyList<string>>>.FromSuccess
-            (
-                new Dictionary<string, IReadOnlyList<string>>
-                {
-                    { "values", data.Values.Value }
-                }
-            ),
+            ComponentType.StringSelect
+                or ComponentType.UserSelect
+                or ComponentType.RoleSelect
+                or ComponentType.MentionableSelect
+                or ComponentType.ChannelSelect
+                => Result<IReadOnlyDictionary<string, IReadOnlyList<string>>>.FromSuccess
+                (
+                    new Dictionary<string, IReadOnlyList<string>>
+                    {
+                        { "values", data.Values.Value }
+                    }
+                ),
             _ => new InvalidOperationError("An unsupported component type was encountered.")
         };
 

--- a/Samples/Interactivity/Commands/InteractiveCommands.cs
+++ b/Samples/Interactivity/Commands/InteractiveCommands.cs
@@ -101,6 +101,7 @@ public class InteractiveCommands : CommandGroup
             {
                 new SelectMenuComponent
                 (
+                    ComponentType.StringSelect,
                     CustomIDHelpers.CreateSelectMenuID("colour-dropdown"),
                     new ISelectOption[]
                     {
@@ -113,6 +114,7 @@ public class InteractiveCommands : CommandGroup
                         new SelectOption("Black", "#000000"),
                         new SelectOption("White", "#FFFFFF")
                     },
+                    default,
                     "Colours...",
                     1,
                     1
@@ -137,6 +139,7 @@ public class InteractiveCommands : CommandGroup
             {
                 new SelectMenuComponent
                 (
+                    ComponentType.StringSelect,
                     CustomIDHelpers.CreateSelectMenuID("typed-dropdown"),
                     new ISelectOption[]
                     {
@@ -144,9 +147,37 @@ public class InteractiveCommands : CommandGroup
                         new SelectOption("Robot", "🤖", Emoji: new PartialEmoji(Name: "🤖")),
                         new SelectOption("Shark", "🦈", Emoji: new PartialEmoji(Name: "🦈"))
                     },
+                    default,
                     "Emojis...",
                     1,
                     1
+                )
+            })
+        });
+
+        return await _feedback.SendContextualEmbedAsync(embed, options, this.CancellationToken);
+    }
+
+    /// <summary>
+    /// Sends an embed with a dropdown allowing the user to select a
+    /// guild text channel.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Command("channel-dropdown")]
+    public async Task<IResult> SendChannelDropdownAsync()
+    {
+        var embed = new Embed(Description: "Select a guild text channel below.");
+        var options = new FeedbackMessageOptions(MessageComponents: new IMessageComponent[]
+        {
+            new ActionRowComponent(new[]
+            {
+                new SelectMenuComponent
+                (
+                    ComponentType.ChannelSelect,
+                    CustomIDHelpers.CreateSelectMenuID("channel-dropdown"),
+                    default,
+                    new[] { ChannelType.GuildText },
+                    "Channels..."
                 )
             })
         });

--- a/Samples/Interactivity/Commands/InteractiveCommands.cs
+++ b/Samples/Interactivity/Commands/InteractiveCommands.cs
@@ -155,23 +155,24 @@ public class InteractiveCommands : CommandGroup
     }
 
     /// <summary>
-    /// Sends an embed with a dropdown allowing the user to select a
-    /// guild text channel.
+    /// Sends an embed with a dropdown allowing the user to select
+    /// users/roles.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Command("channel-dropdown")]
-    public async Task<IResult> SendChannelDropdownAsync()
+    [Command("mentionable-dropdown")]
+    public async Task<IResult> SendMentionableDropdownAsync()
     {
-        var embed = new Embed(Description: "Select a guild text channel below.");
+        var embed = new Embed(Description: "Select users and roles below.");
         var options = new FeedbackMessageOptions(MessageComponents: new IMessageComponent[]
         {
             new ActionRowComponent(new[]
             {
-                new ChannelSelectComponent
+                new MentionableSelectComponent
                 (
-                    CustomIDHelpers.CreateSelectMenuID("channel-dropdown"),
-                    new[] { ChannelType.GuildText },
-                    "Channels..."
+                    CustomIDHelpers.CreateSelectMenuID("mentionable-dropdown"),
+                    "Users/Roles...",
+                    MinValues: 1,
+                    MaxValues: 10
                 )
             })
         });

--- a/Samples/Interactivity/Commands/InteractiveCommands.cs
+++ b/Samples/Interactivity/Commands/InteractiveCommands.cs
@@ -99,9 +99,8 @@ public class InteractiveCommands : CommandGroup
         {
             new ActionRowComponent(new[]
             {
-                new SelectMenuComponent
+                new StringSelectComponent
                 (
-                    ComponentType.StringSelect,
                     CustomIDHelpers.CreateSelectMenuID("colour-dropdown"),
                     new ISelectOption[]
                     {
@@ -114,7 +113,6 @@ public class InteractiveCommands : CommandGroup
                         new SelectOption("Black", "#000000"),
                         new SelectOption("White", "#FFFFFF")
                     },
-                    default,
                     "Colours...",
                     1,
                     1
@@ -137,9 +135,8 @@ public class InteractiveCommands : CommandGroup
         {
             new ActionRowComponent(new[]
             {
-                new SelectMenuComponent
+                new StringSelectComponent
                 (
-                    ComponentType.StringSelect,
                     CustomIDHelpers.CreateSelectMenuID("typed-dropdown"),
                     new ISelectOption[]
                     {
@@ -147,7 +144,6 @@ public class InteractiveCommands : CommandGroup
                         new SelectOption("Robot", "🤖", Emoji: new PartialEmoji(Name: "🤖")),
                         new SelectOption("Shark", "🦈", Emoji: new PartialEmoji(Name: "🦈"))
                     },
-                    default,
                     "Emojis...",
                     1,
                     1
@@ -171,11 +167,9 @@ public class InteractiveCommands : CommandGroup
         {
             new ActionRowComponent(new[]
             {
-                new SelectMenuComponent
+                new ChannelSelectComponent
                 (
-                    ComponentType.ChannelSelect,
                     CustomIDHelpers.CreateSelectMenuID("channel-dropdown"),
-                    default,
                     new[] { ChannelType.GuildText },
                     "Channels..."
                 )

--- a/Samples/Interactivity/Interactions/ColourDropdownInteractions.cs
+++ b/Samples/Interactivity/Interactions/ColourDropdownInteractions.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Remora.Commands.Results;
@@ -156,10 +157,9 @@ public class ColourDropdownInteractions : InteractionGroup
     /// <summary>
     /// Shows the channels selected by the user.
     /// </summary>
-    /// <param name="values">The selected values.</param>
     /// <returns>A result which may or may not have succeeded.</returns>
     [SelectMenu("channel-dropdown")]
-    public async Task<Result> ShowSelectedChannelsAsync(IReadOnlyList<string> values)
+    public async Task<Result> ShowSelectedChannelsAsync()
     {
         if (!_context.Data.TryPickT1(out var components, out _))
         {
@@ -176,15 +176,17 @@ public class ColourDropdownInteractions : InteractionGroup
             return new InvalidOperationError("Expected channel data to be present in the resolved payload");
         }
 
-        var selectedChannels = string.Join(", ", values);
-        var resolvedChannels = string.Join(", ", channels.Keys);
+        var stringBuilder = new StringBuilder();
+        stringBuilder.AppendLine("The following channels were selected: ");
 
-        var message = $"The values of the selected channels were: {selectedChannels}\n\n" +
-            $"The resolved channels were: {resolvedChannels}";
+        foreach (var channel in channels.Keys)
+        {
+            stringBuilder.AppendLine($"• <#{channel}>");
+        }
 
         return (Result)await _feedback.SendContextualNeutralAsync
         (
-            message,
+            stringBuilder.ToString(),
             _context.User.ID,
             options: new FeedbackMessageOptions(MessageFlags: MessageFlags.Ephemeral),
             ct: this.CancellationToken

--- a/Samples/Interactivity/Interactions/ColourDropdownInteractions.cs
+++ b/Samples/Interactivity/Interactions/ColourDropdownInteractions.cs
@@ -100,12 +100,10 @@ public class ColourDropdownInteractions : InteractionGroup
         {
             new ActionRowComponent(new[]
             {
-                new SelectMenuComponent
+                new StringSelectComponent
                 (
-                    ComponentType.StringSelect,
                     dropdown.CustomID,
-                    dropdown.Options,
-                    default,
+                    selectOptions,
                     selected.Label,
                     dropdown.MinValues,
                     dropdown.MaxValues,

--- a/Samples/Interactivity/Interactions/ColourDropdownInteractions.cs
+++ b/Samples/Interactivity/Interactions/ColourDropdownInteractions.cs
@@ -153,40 +153,38 @@ public class ColourDropdownInteractions : InteractionGroup
     }
 
     /// <summary>
-    /// Shows the channels selected by the user.
+    /// Shows the mentionable objects selected by the user.
     /// </summary>
+    /// <param name="users">The resolved channels.</param>
+    /// <param name="roles">The resolved roles.</param>
     /// <returns>A result which may or may not have succeeded.</returns>
-    [SelectMenu("channel-dropdown")]
-    public async Task<Result> ShowSelectedChannelsAsync()
+    [SelectMenu("mentionable-dropdown")]
+    public async Task<Result> ShowSelectedChannelsAsync(IReadOnlyList<IUser> users, IReadOnlyList<IRole> roles)
     {
-        if (!_context.Data.TryPickT1(out var components, out _))
-        {
-            return new InvalidOperationError("Expected message component data to be present");
-        }
-
-        if (!components.Resolved.IsDefined(out var resolvedData))
-        {
-            return new InvalidOperationError("Expected resolved data to be present");
-        }
-
-        if (!resolvedData.Channels.IsDefined(out var channels))
-        {
-            return new InvalidOperationError("Expected channel data to be present in the resolved payload");
-        }
-
         var stringBuilder = new StringBuilder();
-        stringBuilder.AppendLine("The following channels were selected: ");
 
-        foreach (var channel in channels.Keys)
+        stringBuilder.AppendLine("The following users were selected: ");
+        foreach (var channel in users)
         {
-            stringBuilder.AppendLine($"• <#{channel}>");
+            stringBuilder.AppendLine($"• <@{channel.ID}>");
+        }
+
+        stringBuilder.AppendLine();
+        stringBuilder.AppendLine("The following roles were selected: ");
+        foreach (var role in roles)
+        {
+            stringBuilder.AppendLine($"• <@&{role.ID}>");
         }
 
         return (Result)await _feedback.SendContextualNeutralAsync
         (
             stringBuilder.ToString(),
             _context.User.ID,
-            options: new FeedbackMessageOptions(MessageFlags: MessageFlags.Ephemeral),
+            options: new FeedbackMessageOptions
+            (
+                MessageFlags: MessageFlags.Ephemeral,
+                AllowedMentions: new AllowedMentions()
+            ),
             ct: this.CancellationToken
         );
     }

--- a/Samples/Interactivity/Interactions/ColourDropdownInteractions.cs
+++ b/Samples/Interactivity/Interactions/ColourDropdownInteractions.cs
@@ -88,14 +88,13 @@ public class ColourDropdownInteractions : InteractionGroup
         );
 
         var components = new List<IMessageComponent>(message.Components.Value);
-        var dropdown = (ISelectMenuComponent)((IActionRowComponent)components[0]).Components[0];
-
-        if (!dropdown.Options.IsDefined(out var selectOptions))
+        var component = ((IActionRowComponent)components[0]).Components[0];
+        if (component is not IStringSelectComponent dropdown)
         {
-            return new InvalidOperationError("No options were present on the text select");
+            return new InvalidOperationError("Expected a string select component");
         }
 
-        var selected = selectOptions.Single(o => o.Value == colourCodeRaw);
+        var selected = dropdown.Options.Single(o => o.Value == colourCodeRaw);
         var newComponents = new List<IMessageComponent>
         {
             new ActionRowComponent(new[]
@@ -103,7 +102,7 @@ public class ColourDropdownInteractions : InteractionGroup
                 new StringSelectComponent
                 (
                     dropdown.CustomID,
-                    selectOptions,
+                    dropdown.Options,
                     selected.Label,
                     dropdown.MinValues,
                     dropdown.MaxValues,
@@ -159,7 +158,7 @@ public class ColourDropdownInteractions : InteractionGroup
     /// <param name="roles">The resolved roles.</param>
     /// <returns>A result which may or may not have succeeded.</returns>
     [SelectMenu("mentionable-dropdown")]
-    public async Task<Result> ShowSelectedChannelsAsync(IReadOnlyList<IUser> users, IReadOnlyList<IRole> roles)
+    public async Task<Result> ShowSelectedMentionablesAsync(IReadOnlyList<IUser> users, IReadOnlyList<IRole> roles)
     {
         var stringBuilder = new StringBuilder();
 

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/BUTTON_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/BUTTON_COMPONENT.json
@@ -7,6 +7,6 @@
     "id": "999999999999999999",
     "animated": false
   },
-  "custom_id": "click-me",
+  "custom_id": "none",
   "disabled": false
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/BUTTON_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/BUTTON_COMPONENT.optionals.json
@@ -1,5 +1,5 @@
 {
   "type": 2,
   "style": 1,
-  "custom_id": "click-me"
+  "custom_id": "none"
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/CHANNEL_SELECT_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/CHANNEL_SELECT_COMPONENT.json
@@ -1,11 +1,11 @@
 {
   "type": 8,
-  "custom_id": "channel_select_1",
+  "custom_id": "none",
   "channel_types": [
     0,
     1
   ],
-  "placeholder": "Choose a channel",
+  "placeholder": "none",
   "min_values": 1,
   "max_values": 3,
   "disabled": false

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/CHANNEL_SELECT_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/CHANNEL_SELECT_COMPONENT.json
@@ -1,0 +1,12 @@
+{
+  "type": 8,
+  "custom_id": "channel_select_1",
+  "channel_types": [
+    0,
+    1
+  ],
+  "placeholder": "Choose a channel",
+  "min_values": 1,
+  "max_values": 3,
+  "disabled": false
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/CHANNEL_SELECT_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/CHANNEL_SELECT_COMPONENT.optionals.json
@@ -1,4 +1,4 @@
 {
   "type": 8,
-  "custom_id": "channel_select_1"
+  "custom_id": "none"
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/CHANNEL_SELECT_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/CHANNEL_SELECT_COMPONENT.optionals.json
@@ -1,0 +1,4 @@
+{
+  "type": 8,
+  "custom_id": "channel_select_1"
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/MENTIONABLE_SELECT_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/MENTIONABLE_SELECT_COMPONENT.json
@@ -1,0 +1,8 @@
+{
+  "type": 7,
+  "custom_id": "mentionable_select_1",
+  "placeholder": "Choose a mentionable",
+  "min_values": 1,
+  "max_values": 3,
+  "disabled": false
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/MENTIONABLE_SELECT_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/MENTIONABLE_SELECT_COMPONENT.json
@@ -1,7 +1,7 @@
 {
   "type": 7,
-  "custom_id": "mentionable_select_1",
-  "placeholder": "Choose a mentionable",
+  "custom_id": "none",
+  "placeholder": "none",
   "min_values": 1,
   "max_values": 3,
   "disabled": false

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/MENTIONABLE_SELECT_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/MENTIONABLE_SELECT_COMPONENT.optionals.json
@@ -1,0 +1,4 @@
+{
+  "type": 7,
+  "custom_id": "mentionable_select_1"
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/MENTIONABLE_SELECT_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/MENTIONABLE_SELECT_COMPONENT.optionals.json
@@ -1,4 +1,4 @@
 {
   "type": 7,
-  "custom_id": "mentionable_select_1"
+  "custom_id": "none"
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/ROLE_SELECT_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/ROLE_SELECT_COMPONENT.json
@@ -1,7 +1,7 @@
 {
   "type": 6,
-  "custom_id": "role_select_1",
-  "placeholder": "Choose a role",
+  "custom_id": "none",
+  "placeholder": "none",
   "min_values": 1,
   "max_values": 3,
   "disabled": false

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/ROLE_SELECT_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/ROLE_SELECT_COMPONENT.json
@@ -1,0 +1,8 @@
+{
+  "type": 6,
+  "custom_id": "role_select_1",
+  "placeholder": "Choose a role",
+  "min_values": 1,
+  "max_values": 3,
+  "disabled": false
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/ROLE_SELECT_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/ROLE_SELECT_COMPONENT.optionals.json
@@ -1,4 +1,4 @@
 {
   "type": 6,
-  "custom_id": "role_select_1"
+  "custom_id": "none"
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/ROLE_SELECT_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/ROLE_SELECT_COMPONENT.optionals.json
@@ -1,0 +1,4 @@
+{
+  "type": 6,
+  "custom_id": "role_select_1"
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/SELECT_MENU_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/SELECT_MENU_COMPONENT.json
@@ -12,6 +12,10 @@
       }
     }
   ],
+  "channel_types": [
+    0,
+    1
+  ],
   "placeholder": "Choose a class",
   "min_values": 1,
   "max_values": 3,

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/SELECT_MENU_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/SELECT_MENU_COMPONENT.optionals.json
@@ -1,15 +1,4 @@
 {
   "type": 3,
-  "custom_id": "class_select_1",
-  "options": [
-    {
-      "label": "none",
-      "value": "priest",
-      "description": "none",
-      "emoji": {
-        "name": "none",
-        "id": "999999999999999999"
-      }
-    }
-  ]
+  "custom_id": "class_select_1"
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/SELECT_MENU_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/SELECT_MENU_COMPONENT.optionals.json
@@ -1,4 +1,0 @@
-{
-  "type": 3,
-  "custom_id": "class_select_1"
-}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/STRING_SELECT_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/STRING_SELECT_COMPONENT.json
@@ -1,6 +1,6 @@
 {
   "type": 3,
-  "custom_id": "class_select_1",
+  "custom_id": "none",
   "options": [
     {
       "label": "none",
@@ -12,7 +12,7 @@
       }
     }
   ],
-  "placeholder": "Choose a class",
+  "placeholder": "none",
   "min_values": 1,
   "max_values": 3,
   "disabled": false

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/STRING_SELECT_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/STRING_SELECT_COMPONENT.json
@@ -12,10 +12,6 @@
       }
     }
   ],
-  "channel_types": [
-    0,
-    1
-  ],
   "placeholder": "Choose a class",
   "min_values": 1,
   "max_values": 3,

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/STRING_SELECT_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/STRING_SELECT_COMPONENT.optionals.json
@@ -1,6 +1,6 @@
 {
   "type": 3,
-  "custom_id": "class_select_1",
+  "custom_id": "none",
   "options": [
     {
       "label": "none",

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/STRING_SELECT_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/STRING_SELECT_COMPONENT.optionals.json
@@ -1,0 +1,15 @@
+{
+  "type": 3,
+  "custom_id": "class_select_1",
+  "options": [
+    {
+      "label": "none",
+      "value": "priest",
+      "description": "none",
+      "emoji": {
+        "name": "none",
+        "id": "999999999999999999"
+      }
+    }
+  ]
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/TEXT_INPUT_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/TEXT_INPUT_COMPONENT.json
@@ -1,11 +1,11 @@
 {
   "type": 4,
-  "custom_id": "my-input",
+  "custom_id": "none",
   "style": 1,
   "label": "none",
   "min_length": 1,
   "max_length": 2,
   "required": false,
   "value": "bbbb",
-  "placeholder": "cccc"
+  "placeholder": "none"
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/TEXT_INPUT_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/TEXT_INPUT_COMPONENT.optionals.json
@@ -1,6 +1,6 @@
 {
   "type": 4,
-  "custom_id": "my-input",
+  "custom_id": "none",
   "style": 1,
   "label": "none"
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/USER_SELECT_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/USER_SELECT_COMPONENT.json
@@ -1,7 +1,7 @@
 {
   "type": 5,
-  "custom_id": "user_select_1",
-  "placeholder": "Choose a user",
+  "custom_id": "none",
+  "placeholder": "none",
   "min_values": 1,
   "max_values": 3,
   "disabled": false

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/USER_SELECT_COMPONENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/USER_SELECT_COMPONENT.json
@@ -1,0 +1,8 @@
+{
+  "type": 5,
+  "custom_id": "user_select_1",
+  "placeholder": "Choose a user",
+  "min_values": 1,
+  "max_values": 3,
+  "disabled": false
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/USER_SELECT_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/USER_SELECT_COMPONENT.optionals.json
@@ -1,4 +1,4 @@
 {
   "type": 5,
-  "custom_id": "user_select_1"
+  "custom_id": "none"
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/USER_SELECT_COMPONENT.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT/USER_SELECT_COMPONENT.optionals.json
@@ -1,0 +1,4 @@
+{
+  "type": 5,
+  "custom_id": "user_select_1"
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT_DATA/MESSAGE_COMPONENT_DATA.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT_DATA/MESSAGE_COMPONENT_DATA.json
@@ -1,5 +1,6 @@
 {
   "custom_id": "none",
   "component_type": 0,
+  "resolved": {},
   "values": []
 }

--- a/Tools/Remora.Discord.SensitiveDataScrubber/patterns.json
+++ b/Tools/Remora.Discord.SensitiveDataScrubber/patterns.json
@@ -23,7 +23,7 @@
         "value_pattern": "^\"[a-zA-Z0-9]+\"$",
         "replacement": "\"123456\""
     },
-    "^(((user)?name)|nick|description|content|label|summary|topic|small_text|large_text|state|details|buttons|tags)$": {
+    "^(((user)?name)|nick|description|content|label|summary|topic|small_text|large_text|state|details|buttons|tags|custom_id|placeholder)$": {
         "value_pattern": "^\".+\"$",
         "replacement": "\"none\""
     },


### PR DESCRIPTION
This PR implements support for the new select menu types (specifically, `user`, `role`, `mentionable` and `channel`). See https://github.com/discord/discord-api-docs/pull/5543 for more information.

As part of supporting this, I modified the `SelectMenuComponent` to require a specific `ComponentType` as a constructor parameter, rather than being auto-implemented like in other message component types. If retaining this pattern is preferred, a new type could be created for each select menu type, such as `ChannelSelectComponent`.

The `CustomIDHelpers` utils previously used the `ComponentType#SelectMenu` enum value to generate IDs for select menu interactions. The `SelectMenu` definition is now known as `StringSelect`. In order to prevent breaking previous interactions, I modified `CustomIDHelpers#CreateSelectMenuID` to always use the previous value of `"select-menu"`, regardless of the menu component type.