### PR TITLE
Make RedisCacheProvider pass values as byte[] directly instead of serializing to string

### DIFF
--- a/Backend/Remora.Discord.Caching.Redis/Services/RedisCacheProvider.cs
+++ b/Backend/Remora.Discord.Caching.Redis/Services/RedisCacheProvider.cs
@@ -75,7 +75,7 @@ public class RedisCacheProvider : ICacheProvider
             return;
         }
 
-        var serialized = JsonSerializer.Serialize(instance, _jsonOptions);
+        var serialized = JsonSerializer.SerializeToUtf8Bytes(instance, _jsonOptions);
 
         var options = new DistributedCacheEntryOptions
         {
@@ -83,7 +83,7 @@ public class RedisCacheProvider : ICacheProvider
             SlidingExpiration = slidingExpiration
         };
 
-        await _cache.SetStringAsync(key, serialized, options, ct);
+        await _cache.SetAsync(key, serialized, options, ct);
     }
 
     /// <inheritdoc cref="ICacheProvider.RetrieveAsync{TInstance}"/>


### PR DESCRIPTION
The current implementation of `RedisCacheProvider.CacheAsync` serializes into a string, then passes that to the RedisCache; passing a byte array should be more friendly to the System.Text.Json serializer and reduce string processing overhead.

This PR uses `JsonSerializer.SerializeToUtf8Bytes` and the `byte[]` overload of `IDistributedCache.SetAsync` for this.