### PR TITLE
Add assembly discovery extension methods

### DIFF
--- a/Remora.Discord.Extensions/Attributes/ResponderAttribute.cs
+++ b/Remora.Discord.Extensions/Attributes/ResponderAttribute.cs
@@ -1,5 +1,5 @@
 //
-//  ResponderGroupAttribute.cs
+//  ResponderAttribute.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -29,10 +29,19 @@ namespace Remora.Discord.Extensions.Attributes;
 /// Indicates that a responder type or method should be registered as the specified group.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class)]
-public class ResponderGroupAttribute : Attribute
+public class ResponderAttribute : Attribute
 {
     /// <summary>
     /// Gets the group to register the responder as.
     /// </summary>
     public ResponderGroup Group { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResponderAttribute"/> class.
+    /// </summary>
+    /// <param name="group">The responder group the responder should be added to, defaulting to <see cref="ResponderGroup.Normal"/>.</param>
+    public ResponderAttribute(ResponderGroup group = ResponderGroup.Normal)
+    {
+        this.Group = group;
+    }
 }

--- a/Remora.Discord.Extensions/Attributes/ResponderGroupAttribute.cs
+++ b/Remora.Discord.Extensions/Attributes/ResponderGroupAttribute.cs
@@ -1,0 +1,38 @@
+//
+//  ResponderGroupAttribute.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using Remora.Discord.Gateway.Responders;
+
+namespace Remora.Discord.Extensions.Attributes;
+
+/// <summary>
+/// Indicates that a responder type or method should be registered as the specified group.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class ResponderGroupAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the group to register the responder as.
+    /// </summary>
+    public ResponderGroup Group { get; }
+}

--- a/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
@@ -59,11 +59,11 @@ public static class ServiceCollectionExtensions
 
         var tree = serviceCollection.AddCommandTree(treeName);
 
-        foreach (var canidate in candidates)
+        foreach (var candidate in candidates)
         {
-            if (typeFilter?.Invoke(canidate) ?? true)
+            if (typeFilter?.Invoke(candidate) ?? true)
             {
-                tree.WithCommandGroup(canidate);
+                tree.WithCommandGroup(candidate);
             }
         }
 
@@ -85,11 +85,11 @@ public static class ServiceCollectionExtensions
                                              .Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IResponder<>)))
                                 .ToArray();
 
-        foreach (var canidate in candidates)
+        foreach (var candidate in candidates)
         {
-            var grouping = canidate.GetCustomAttribute(typeof(ResponderGroupAttribute)) as ResponderGroupAttribute;
+            var grouping = candidate.GetCustomAttribute(typeof(ResponderGroupAttribute)) as ResponderGroupAttribute;
 
-            serviceCollection.AddResponder(canidate, grouping?.Group ?? ResponderGroup.Normal);
+            serviceCollection.AddResponder(candidate, grouping?.Group ?? ResponderGroup.Normal);
         }
 
         return serviceCollection;

--- a/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
@@ -53,7 +53,7 @@ public static class ServiceCollectionExtensions
         Func<Type, bool>? typeFilter = null
     )
     {
-        var candidates = assembly.GetTypes()
+        var candidates = assembly.ExportedTypes
                                 .Where(t => t.IsClass && !t.IsAbstract && typeof(CommandGroup).IsAssignableFrom(t))
                                 .ToArray();
 
@@ -87,7 +87,7 @@ public static class ServiceCollectionExtensions
 
         foreach (var candidate in candidates)
         {
-            var grouping = candidate.GetCustomAttribute(typeof(ResponderGroupAttribute)) as ResponderGroupAttribute;
+            var grouping = candidate.GetCustomAttribute(typeof(ResponderAttribute)) as ResponderAttribute;
 
             serviceCollection.AddResponder(candidate, grouping?.Group ?? ResponderGroup.Normal);
         }

--- a/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
@@ -76,7 +76,7 @@ public static class ServiceCollectionExtensions
     /// <param name="serviceCollection">The service collection to register responders in.</param>
     /// <param name="assembly">The assembly to discover responders from.</param>
     /// <returns>The service collection to chain calls.</returns>
-    public static IServiceCollection AddResponders(this IServiceCollection serviceCollection, Assembly assembly)
+    public static IServiceCollection AddRespondersFromAssembly(this IServiceCollection serviceCollection, Assembly assembly)
     {
         var canidates = assembly.GetTypes()
                                 .Where(t => t.IsClass &&

--- a/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,7 @@ public static class ServiceCollectionExtensions
     /// <param name="treeName">The name of the tree to register commands to, otherwise the default.</param>
     /// <param name="typeFilter">A function to select whether a given command group should be registered.</param>
     /// <returns>The service collection with registered commands.</returns>
-    public static IServiceCollection AddCommandModulesFromAssembly
+    public static IServiceCollection AddCommandGroupsFromAssembly
     (
         this IServiceCollection serviceCollection,
         Assembly assembly,

--- a/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,97 @@
+//
+//  ServiceCollectionExtensions.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Remora.Commands.Extensions;
+using Remora.Commands.Groups;
+using Remora.Discord.Extensions.Attributes;
+using Remora.Discord.Gateway.Extensions;
+using Remora.Discord.Gateway.Responders;
+
+namespace Remora.Discord.Extensions.Extensions;
+
+/// <summary>
+/// A collection of extensions for the <see cref="IServiceCollection"/> interface.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Automatically registers every command group in the given assembly.
+    /// </summary>
+    /// <param name="serviceCollection">The service collection to add commands to.</param>
+    /// <param name="assembly">The assembly to discover command groups from.</param>
+    /// <param name="treeName">The name of the tree to register commands to, otherwise the default.</param>
+    /// <param name="typeFilter">A function to select whether a given command group should be registered.</param>
+    /// <returns>The service collection with registered commands.</returns>
+    public static IServiceCollection AddDiscordCommands
+    (
+        this IServiceCollection serviceCollection,
+        Assembly assembly,
+        string? treeName = null,
+        Func<Type, bool>? typeFilter = null
+    )
+    {
+        var canidates = assembly.GetTypes()
+                                .Where(t => t.IsClass && !t.IsAbstract && typeof(CommandGroup).IsAssignableFrom(t))
+                                .ToArray();
+
+        var tree = serviceCollection.AddCommandTree(treeName);
+
+        foreach (var canidate in canidates)
+        {
+            if (typeFilter?.Invoke(canidate) ?? true)
+            {
+                tree.WithCommandGroup(canidate);
+            }
+        }
+
+        return serviceCollection;
+    }
+
+    /// <summary>
+    /// Adds all responders in the given assembly to the service collection, using their attributed group if possible.
+    /// </summary>
+    /// <param name="serviceCollection">The service collection to register responders in.</param>
+    /// <param name="assembly">The assembly to discover responders from.</param>
+    /// <returns>The service collection to chain calls.</returns>
+    public static IServiceCollection AddResponders(this IServiceCollection serviceCollection, Assembly assembly)
+    {
+        var canidates = assembly.GetTypes()
+                                .Where(t => t.IsClass &&
+                                           !t.IsAbstract &&
+                                            t.GetInterfaces() // .Any(t => typeof(IResponder).IsAssignableFrom(t)) ?
+                                             .Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IResponder<>)))
+                                .ToArray();
+
+        foreach (var canidate in canidates)
+        {
+            var grouping = canidate.GetCustomAttribute(typeof(ResponderGroupAttribute)) as ResponderGroupAttribute;
+
+            serviceCollection.AddResponder(canidate, grouping?.Group ?? ResponderGroup.Normal);
+        }
+
+        return serviceCollection;
+    }
+}

--- a/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,7 @@ public static class ServiceCollectionExtensions
     /// <param name="treeName">The name of the tree to register commands to, otherwise the default.</param>
     /// <param name="typeFilter">A function to select whether a given command group should be registered.</param>
     /// <returns>The service collection with registered commands.</returns>
-    public static IServiceCollection AddDiscordCommands
+    public static IServiceCollection AddCommandModulesFromAssembly
     (
         this IServiceCollection serviceCollection,
         Assembly assembly,
@@ -53,13 +53,13 @@ public static class ServiceCollectionExtensions
         Func<Type, bool>? typeFilter = null
     )
     {
-        var canidates = assembly.GetTypes()
+        var candidates = assembly.GetTypes()
                                 .Where(t => t.IsClass && !t.IsAbstract && typeof(CommandGroup).IsAssignableFrom(t))
                                 .ToArray();
 
         var tree = serviceCollection.AddCommandTree(treeName);
 
-        foreach (var canidate in canidates)
+        foreach (var canidate in candidates)
         {
             if (typeFilter?.Invoke(canidate) ?? true)
             {
@@ -81,7 +81,7 @@ public static class ServiceCollectionExtensions
         var canidates = assembly.GetTypes()
                                 .Where(t => t.IsClass &&
                                            !t.IsAbstract &&
-                                            t.GetInterfaces() // .Any(t => typeof(IResponder).IsAssignableFrom(t)) ?
+                                            t.GetInterfaces()
                                              .Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IResponder<>)))
                                 .ToArray();
 

--- a/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
@@ -78,14 +78,14 @@ public static class ServiceCollectionExtensions
     /// <returns>The service collection to chain calls.</returns>
     public static IServiceCollection AddRespondersFromAssembly(this IServiceCollection serviceCollection, Assembly assembly)
     {
-        var canidates = assembly.GetTypes()
+        var candidates = assembly.GetTypes()
                                 .Where(t => t.IsClass &&
                                            !t.IsAbstract &&
                                             t.GetInterfaces()
                                              .Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IResponder<>)))
                                 .ToArray();
 
-        foreach (var canidate in canidates)
+        foreach (var canidate in candidates)
         {
             var grouping = canidate.GetCustomAttribute(typeof(ResponderGroupAttribute)) as ResponderGroupAttribute;
 

--- a/Remora.Discord.Extensions/Remora.Discord.Extensions.csproj
+++ b/Remora.Discord.Extensions/Remora.Discord.Extensions.csproj
@@ -11,6 +11,11 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Backend\Remora.Discord.API\Remora.Discord.API.csproj" />
+        <ProjectReference Include="..\Backend\Remora.Discord.Gateway\Remora.Discord.Gateway.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Remora.Commands" Version="10.0.2" />
     </ItemGroup>
 
 </Project>

--- a/Tests/Remora.Discord.Extensions.Tests/Samples/TestCommand.cs
+++ b/Tests/Remora.Discord.Extensions.Tests/Samples/TestCommand.cs
@@ -1,0 +1,44 @@
+//
+//  TestCommand.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Threading.Tasks;
+using Remora.Commands.Attributes;
+using Remora.Commands.Groups;
+using Remora.Results;
+
+namespace Remora.Discord.Extensions.Tests.Samples;
+
+/// <summary>
+/// A test command group.
+/// </summary>
+public class TestCommand : CommandGroup
+{
+    /// <summary>
+    /// A test command.
+    /// </summary>
+    /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+    [Command("test")]
+    public Task<IResult> TestAsync()
+    {
+        return Task.FromResult<IResult>(Result.FromSuccess());
+    }
+}

--- a/Tests/Remora.Discord.Extensions.Tests/Samples/TestResponder.cs
+++ b/Tests/Remora.Discord.Extensions.Tests/Samples/TestResponder.cs
@@ -1,0 +1,49 @@
+//
+//  TestResponder.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Threading;
+using System.Threading.Tasks;
+using Remora.Discord.API.Abstractions.Gateway.Events;
+using Remora.Discord.Extensions.Attributes;
+using Remora.Discord.Gateway.Responders;
+using Remora.Results;
+
+namespace Remora.Discord.Extensions.Tests.Samples;
+
+/// <summary>
+/// A test responder.
+/// </summary>
+[Responder]
+public class TestResponder : IResponder<IMessageCreate>, IResponder<IMessageDelete>
+{
+    /// <inheritdoc/>
+    public Task<Result> RespondAsync(IMessageCreate gatewayEvent, CancellationToken ct = default)
+    {
+        return Task.FromResult(Result.FromSuccess());
+    }
+
+    /// <inheritdoc/>
+    public Task<Result> RespondAsync(IMessageDelete gatewayEvent, CancellationToken ct = default)
+    {
+        return Task.FromResult(Result.FromSuccess());
+    }
+}

--- a/Tests/Remora.Discord.Extensions.Tests/ServiceCollectionExtensionsTests.cs
+++ b/Tests/Remora.Discord.Extensions.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,89 @@
+//
+//  ServiceCollectionExtensionsTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Remora.Commands.Extensions;
+using Remora.Commands.Services;
+using Remora.Discord.API.Abstractions.Gateway.Events;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Extensions.Extensions;
+using Remora.Discord.Extensions.Tests.Samples;
+using Remora.Discord.Gateway.Extensions;
+using Remora.Discord.Gateway.Services;
+using Xunit;
+
+namespace Remora.Discord.Extensions.Tests;
+
+/// <summary>
+/// Tests for <see cref="Remora.Discord.Extensions.Extensions.ServiceCollectionExtensions"/>.
+/// </summary>
+public class ServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// Tests that the method successfully registers all commands from the assembly.
+    /// </summary>
+    [Fact]
+    public void AddsCommandGroupsFromAssemblySuccessfully()
+    {
+        var services = new ServiceCollection();
+
+        services
+            .AddCommands()
+            .AddCommandGroupsFromAssembly(typeof(ServiceCollectionExtensionsTests).Assembly);
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        var commandTree = serviceProvider.GetRequiredService<CommandTreeAccessor>();
+
+        var treeExists = commandTree.TryGetNamedTree(null, out var tree);
+
+        Assert.True(treeExists);
+        Assert.NotEmpty(tree!.Root.Children);
+    }
+
+    /// <summary>
+    /// Tests that the method successfully registers all responders from the assembly.
+    /// </summary>
+    [Fact]
+    public void AddsRespondersFromAssemblySuccessfully()
+    {
+        var services = new ServiceCollection();
+
+        services
+            .AddDiscordGateway(_ => "ooga")
+            .AddRespondersFromAssembly(typeof(ServiceCollectionExtensionsTests).Assembly);
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        var responderRepo = serviceProvider.GetRequiredService<IResponderTypeRepository>();
+
+        var messageCreateResponders = responderRepo.GetResponderTypes<IMessageCreate>().ToArray();
+        var messageDeleteResponders = responderRepo.GetResponderTypes<IMessageDelete>().ToArray();
+
+        var messageCreateType = Assert.Single(messageCreateResponders);
+        Assert.Equal(typeof(TestResponder), messageCreateType);
+
+        var messageDeleteType = Assert.Single(messageDeleteResponders);
+        Assert.Equal(typeof(TestResponder), messageDeleteType);
+    }
+}


### PR DESCRIPTION
This PR adds helper methods that register responders and commands based on assembly discovery.

This was pitched by @cmsteffey, since other libraries have this functionality (usually in addition to explicit registrations, such as D#+)