### PR TITLE
Throw exception for invalid parameters when registering context menu commands

### DIFF
--- a/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
@@ -458,17 +458,14 @@ public static class CommandTreeExtensions
             }
 
             var parameters = command.CommandMethod.GetParameters();
-            if (parameters.Length > 0)
+            var expectedParameter = commandType.AsParameterName();
+            if (parameters.Length != 1 || parameters[0].Name != expectedParameter)
             {
-                var expectedParameter = commandType.AsParameterName();
-                if (parameters.Length != 1 || parameters[0].Name != expectedParameter)
-                {
-                    throw new InvalidNodeException
-                    (
-                        $"{commandType.Humanize()} context menu commands may only have a single parameter named {expectedParameter}.",
-                        command
-                    );
-                }
+                throw new InvalidNodeException
+                (
+                    $"{commandType.Humanize()} context menu commands may only have a single parameter named {expectedParameter}.",
+                    command
+                );
             }
         }
 

--- a/Samples/Localization/Commands/HttpCatCommands.cs
+++ b/Samples/Localization/Commands/HttpCatCommands.cs
@@ -26,48 +26,25 @@ namespace Remora.Discord.Samples.Localization.Commands;
 public class HttpCatCommands : CommandGroup
 {
     private readonly FeedbackService _feedbackService;
-    private readonly ICommandContext _context;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HttpCatCommands"/> class.
     /// </summary>
     /// <param name="feedbackService">The feedback service.</param>
-    /// <param name="context">The command context.</param>
-    public HttpCatCommands(FeedbackService feedbackService, ICommandContext context)
+    public HttpCatCommands(FeedbackService feedbackService)
     {
         _feedbackService = feedbackService;
-        _context = context;
     }
 
     /// <summary>
     /// Posts a cat image that matches the user.
     /// </summary>
+    /// <param name="user">The user selected.</param>
     /// <returns>The result of the command.</returns>
     [Command("Cattify")]
     [CommandType(ApplicationCommandType.User)]
-    public async Task<IResult> PostContextualUserHttpCatAsync()
+    public async Task<IResult> PostContextualUserHttpCatAsync(IUser user)
     {
-        if (_context is not IInteractionContext interactionContext)
-        {
-            return Result.FromSuccess();
-        }
-
-        if (!interactionContext.Interaction.Data.IsDefined(out var data) || !data.TryPickT0(out var commandData, out _))
-        {
-            return Result.FromSuccess();
-        }
-
-        if (!commandData.Resolved.IsDefined(out var resolved))
-        {
-            return Result.FromSuccess();
-        }
-
-        if (!resolved.Users.IsDefined(out var users))
-        {
-            return Result.FromSuccess();
-        }
-
-        var user = users.First().Value;
         return await PostUserHttpCatAsync(user);
     }
 

--- a/Samples/SlashCommands/Commands/HttpCatCommands.cs
+++ b/Samples/SlashCommands/Commands/HttpCatCommands.cs
@@ -14,7 +14,6 @@ using Remora.Commands.Groups;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Objects;
 using Remora.Discord.Commands.Attributes;
-using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Feedback.Services;
 using Remora.Results;
 
@@ -26,48 +25,25 @@ namespace Remora.Discord.Samples.SlashCommands.Commands;
 public class HttpCatCommands : CommandGroup
 {
     private readonly FeedbackService _feedbackService;
-    private readonly ICommandContext _context;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HttpCatCommands"/> class.
     /// </summary>
     /// <param name="feedbackService">The feedback service.</param>
-    /// <param name="context">The command context.</param>
-    public HttpCatCommands(FeedbackService feedbackService, ICommandContext context)
+    public HttpCatCommands(FeedbackService feedbackService)
     {
         _feedbackService = feedbackService;
-        _context = context;
     }
 
     /// <summary>
     /// Posts a cat image that matches the user.
     /// </summary>
+    /// <param name="user">The user selected.</param>
     /// <returns>The result of the command.</returns>
     [Command("Cattify")]
     [CommandType(ApplicationCommandType.User)]
-    public async Task<IResult> PostContextualUserHttpCatAsync()
+    public async Task<IResult> PostContextualUserHttpCatAsync(IUser user)
     {
-        if (_context is not IInteractionContext interactionContext)
-        {
-            return Result.FromSuccess();
-        }
-
-        if (!interactionContext.Interaction.Data.IsDefined(out var data) || !data.TryPickT0(out var commandData, out _))
-        {
-            return Result.FromSuccess();
-        }
-
-        if (!commandData.Resolved.IsDefined(out var resolved))
-        {
-            return Result.FromSuccess();
-        }
-
-        if (!resolved.Users.IsDefined(out var users))
-        {
-            return Result.FromSuccess();
-        }
-
-        var user = users.First().Value;
         return await PostUserHttpCatAsync(user);
     }
 

--- a/Tests/Remora.Discord.Commands.Tests/Data/DiscordLimits/ContextMenusWithoutParametersAreNotSupported.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Data/DiscordLimits/ContextMenusWithoutParametersAreNotSupported.cs
@@ -1,5 +1,5 @@
 //
-//  ContextMenusWithDescriptionsAreNotSupported.cs
+//  ContextMenusWithoutParametersAreNotSupported.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -21,23 +21,24 @@
 //
 
 using System;
-using System.ComponentModel;
 using System.Threading.Tasks;
 using Remora.Commands.Attributes;
 using Remora.Commands.Groups;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.Commands.Attributes;
-using Remora.Rest.Core;
 using Remora.Results;
 
 #pragma warning disable CS1591, SA1600
 
 namespace Remora.Discord.Commands.Tests.Data.DiscordLimits;
 
-public class ContextMenusWithDescriptionsAreNotSupported : CommandGroup
+public class ContextMenusWithoutParametersAreNotSupported : CommandGroup
 {
-    [Command("Do thing")]
+    [Command("Do user thing")]
     [CommandType(ApplicationCommandType.User)]
-    [Description("Oh no!")]
-    public Task<IResult> ContextCommand(Snowflake user) => throw new NotImplementedException();
+    public Task<IResult> UserContextCommand() => throw new NotImplementedException();
+
+    [Command("Do message thing")]
+    [CommandType(ApplicationCommandType.Message)]
+    public Task<IResult> MessageContextCommand() => throw new NotImplementedException();
 }

--- a/Tests/Remora.Discord.Commands.Tests/Data/Valid/GroupWithContextMenuAndCommand.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Data/Valid/GroupWithContextMenuAndCommand.cs
@@ -26,6 +26,7 @@ using Remora.Commands.Attributes;
 using Remora.Commands.Groups;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.Commands.Attributes;
+using Remora.Rest.Core;
 using Remora.Results;
 
 #pragma warning disable CS1591, SA1600, SA1402, SA1602
@@ -39,5 +40,5 @@ public class GroupWithContextMenuAndCommand : CommandGroup
 
     [Command("Do message thing")]
     [CommandType(ApplicationCommandType.Message)]
-    public Task<IResult> MessageCommand() => throw new NotImplementedException();
+    public Task<IResult> MessageCommand(Snowflake message) => throw new NotImplementedException();
 }

--- a/Tests/Remora.Discord.Commands.Tests/Data/Valid/GroupWithContextMenus.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Data/Valid/GroupWithContextMenus.cs
@@ -37,17 +37,9 @@ public class GroupWithContextMenus : CommandGroup
 {
     [Command("Do user thing")]
     [CommandType(ApplicationCommandType.User)]
-    public Task<IResult> UserCommand() => throw new NotImplementedException();
+    public Task<IResult> UserCommand(Snowflake user) => throw new NotImplementedException();
 
     [Command("Do message thing")]
     [CommandType(ApplicationCommandType.Message)]
-    public Task<IResult> MessageCommand() => throw new NotImplementedException();
-
-    [Command("Do user thing with parameter")]
-    [CommandType(ApplicationCommandType.User)]
-    public Task<IResult> UserCommandParameter(Snowflake user) => throw new NotImplementedException();
-
-    [Command("Do message thing with parameter")]
-    [CommandType(ApplicationCommandType.Message)]
-    public Task<IResult> MessageCommandParameter(Snowflake message) => throw new NotImplementedException();
+    public Task<IResult> MessageCommand(Snowflake message) => throw new NotImplementedException();
 }

--- a/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
@@ -283,6 +283,20 @@ public class CommandTreeExtensionTests
             }
 
             /// <summary>
+            /// Tests whether the method responds appropriately to a failure case.
+            /// </summary>
+            [Fact]
+            public void ThrowsIfContextMenuHasNoParameters()
+            {
+                var builder = new CommandTreeBuilder();
+                builder.RegisterModule<ContextMenusWithoutParametersAreNotSupported>();
+
+                var tree = builder.Build();
+
+                Assert.Throws<InvalidNodeException>(() => tree.CreateApplicationCommands());
+            }
+
+            /// <summary>
             /// Tests whether method responds appropriately to a failure case.
             /// </summary>
             [Fact]
@@ -561,17 +575,13 @@ public class CommandTreeExtensionTests
 
                 var commands = tree.CreateApplicationCommands();
 
-                Assert.Equal(4, commands.Count);
+                Assert.Equal(2, commands.Count);
 
                 var user = commands[0];
                 var message = commands[1];
-                var userParameter = commands[2];
-                var messageParameter = commands[3];
 
                 Assert.Equal(ApplicationCommandType.User, user.Type.Value);
                 Assert.Equal(ApplicationCommandType.Message, message.Type.Value);
-                Assert.Equal(ApplicationCommandType.User, userParameter.Type.Value);
-                Assert.Equal(ApplicationCommandType.Message, messageParameter.Type.Value);
             }
 
             /// <summary>


### PR DESCRIPTION
This PR fixes the issue that arises when one has a context menu command without any parameter.

As it will always expect at least 1 parameter. (`user` for User commands and `message` for Message commands)
Therefore an exception will now be also thrown when the command does not have any parameters at all.