### PR TITLE
Implement role connections API endpoints and objects

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/ApplicationRoleConnectionMetadataType.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/ApplicationRoleConnectionMetadataType.cs
@@ -1,0 +1,72 @@
+//
+//  ApplicationRoleConnectionMetadataType.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Enumerates various application role connection metadata types.
+/// </summary>
+[PublicAPI]
+public enum ApplicationRoleConnectionMetadataType
+{
+    /// <summary>
+    /// The metadata value (integer) is less than or equal to the guild's configured value (integer).
+    /// </summary>
+    IntegerLessThanOrEqual = 1,
+
+    /// <summary>
+    /// The metadata value (integer) is greater than or equal to the guild's configured value (integer).
+    /// </summary>
+    IntegerGreaterThanOrEqual = 2,
+
+    /// <summary>
+    /// The metadata value (integer) is equal to the guild's configured value (integer).
+    /// </summary>
+    IntegerEqual = 3,
+
+    /// <summary>
+    /// The metadata value (integer) is not equal to the guild's configured value (integer).
+    /// </summary>
+    IntegerNotEqual = 4,
+
+    /// <summary>
+    /// The metadata value (ISO8601 string) is less than or equal to the guild's configured value (integer; days before current date).
+    /// </summary>
+    DateTimeLessThanOrEqual = 5,
+
+    /// <summary>
+    /// The metadata value (ISO8601 string) is greater than or equal to the guild's configured value (integer; days before current date).
+    /// </summary>
+    DateTimeGreaterThanOrEqual = 6,
+
+    /// <summary>
+    /// The metadata value (integer) is equal to the guild's configured value (integer; 1).
+    /// </summary>
+    BooleanEqual = 7,
+
+    /// <summary>
+    /// The metadata value (integer) is not equal to the guild's configured value (integer; 1).
+    /// </summary>
+    BooleanNotEqual = 8,
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/IApplication.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/IApplication.cs
@@ -133,6 +133,13 @@ public interface IApplication : IPartialApplication
     /// </summary>
     new Optional<Uri> CustomInstallUrl { get; }
 
+    /// <summary>
+    /// Gets the application's role connection verification entry point,
+    /// which when configured will render the app as a verification method
+    /// in the guild role verification configuration.
+    /// </summary>
+    new Optional<Uri> RoleConnectionsVerificationUrl { get; }
+
     /// <inheritdoc/>
     Optional<Snowflake> IPartialApplication.ID => this.ID;
 
@@ -185,11 +192,14 @@ public interface IApplication : IPartialApplication
     Optional<ApplicationFlags> IPartialApplication.Flags => this.Flags;
 
     /// <inheritdoc/>
-    Optional<IReadOnlyList<string>> IPartialApplication.Tags => throw new NotImplementedException();
+    Optional<IReadOnlyList<string>> IPartialApplication.Tags => this.Tags;
 
     /// <inheritdoc/>
-    Optional<IApplicationInstallParameters> IPartialApplication.InstallParams => throw new NotImplementedException();
+    Optional<IApplicationInstallParameters> IPartialApplication.InstallParams => this.InstallParams;
 
     /// <inheritdoc/>
-    Optional<Uri> IPartialApplication.CustomInstallUrl => throw new NotImplementedException();
+    Optional<Uri> IPartialApplication.CustomInstallUrl => this.CustomInstallUrl;
+
+    /// <inheritdoc/>
+    Optional<Uri> IPartialApplication.RoleConnectionsVerificationUrl => this.RoleConnectionsVerificationUrl;
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/IApplicationRoleConnectionMetadata.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/IApplicationRoleConnectionMetadata.cs
@@ -40,13 +40,13 @@ public interface IApplicationRoleConnectionMetadata
     /// <summary>
     /// Gets the dictionary key for the metadata field.
     /// </summary>
-    /// <remarks>The key must only consist of a-z, 0-9 or _ and must have a length between 1 and 50 characters.</remarks>
+    /// <remarks>The key must only consist of a-z, 0-9 or _ and must have a length of max. 50 characters.</remarks>
     string Key { get; }
 
     /// <summary>
     /// Gets the name of the metadata field.
     /// </summary>
-    /// <remarks>The length of the name must be between 1 and 100 characters.</remarks>
+    /// <remarks>The length of the name must be max. 100 characters.</remarks>
     string Name { get; }
 
     /// <summary>
@@ -57,7 +57,7 @@ public interface IApplicationRoleConnectionMetadata
     /// <summary>
     /// Gets the description of the metadata field.
     /// </summary>
-    /// <remarks>The length of the description must be between 1 and 200 characters.</remarks>
+    /// <remarks>The length of the description must be max. 200 characters.</remarks>
     string Description { get; }
 
     /// <summary>

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/IApplicationRoleConnectionMetadata.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/IApplicationRoleConnectionMetadata.cs
@@ -1,0 +1,67 @@
+//
+//  IApplicationRoleConnectionMetadata.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents an application role connection metadata field.
+/// </summary>
+[PublicAPI]
+public interface IApplicationRoleConnectionMetadata
+{
+    /// <summary>
+    /// Gets the type of metadata value.
+    /// </summary>
+    ApplicationRoleConnectionMetadataType Type { get; }
+
+    /// <summary>
+    /// Gets the dictionary key for the metadata field.
+    /// </summary>
+    /// <remarks>The key must only consist of a-z, 0-9 or _ and must have a length between 1 and 50 characters.</remarks>
+    string Key { get; }
+
+    /// <summary>
+    /// Gets the name of the metadata field.
+    /// </summary>
+    /// <remarks>The length of the name must be between 1 and 100 characters.</remarks>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the localized names of the metadata field.
+    /// </summary>
+    Optional<IReadOnlyDictionary<string, string>> NameLocalizations { get; }
+
+    /// <summary>
+    /// Gets the description of the metadata field.
+    /// </summary>
+    /// <remarks>The length of the description must be between 1 and 200 characters.</remarks>
+    string Description { get; }
+
+    /// <summary>
+    /// Gets the localized descriptions of the metadata field.
+    /// </summary>
+    Optional<IReadOnlyDictionary<string, string>> DescriptionLocalizations { get; }
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/IPartialApplication.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/IPartialApplication.cs
@@ -92,4 +92,7 @@ public interface IPartialApplication
 
     /// <inheritdoc cref="IApplication.CustomInstallUrl" />
     Optional<Uri> CustomInstallUrl { get; }
+
+    /// <inheritdoc cref="IApplication.RoleConnectionsVerificationUrl" />
+    Optional<Uri> RoleConnectionsVerificationUrl { get; }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IApplicationRoleConnection.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IApplicationRoleConnection.cs
@@ -1,0 +1,53 @@
+//
+//  IApplicationRoleConnection.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents a role connection that an application has attached to an user.
+/// </summary>
+[PublicAPI]
+public interface IApplicationRoleConnection
+{
+    /// <summary>
+    /// Gets the vanity name of the platform a bot has connected.
+    /// </summary>
+    /// <remarks>The length of the platform username must be max. 50 characters.</remarks>
+    Optional<string> PlatformName { get; }
+
+    /// <summary>
+    /// Gets the username on the platform a bot has connected.
+    /// </summary>
+    /// <remarks>The length of the platform username must be max. 100 characters.</remarks>
+    Optional<string> PlatformUsername { get; }
+
+    /// <summary>
+    /// Gets the object mapping of <see cref="IApplicationRoleConnectionMetadata.Key"/> to their stringified value
+    /// for the user on the platform a bot has connected.
+    /// </summary>
+    /// <remarks>The length of the stringified value must max. 100 characters.</remarks>
+    Optional<IReadOnlyDictionary<string, string>> Metadata { get; }
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IApplicationRoleConnection.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IApplicationRoleConnection.cs
@@ -22,7 +22,6 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using Remora.Rest.Core;
 
 namespace Remora.Discord.API.Abstractions.Objects;
 
@@ -36,18 +35,18 @@ public interface IApplicationRoleConnection
     /// Gets the vanity name of the platform a bot has connected.
     /// </summary>
     /// <remarks>The length of the platform username must be max. 50 characters.</remarks>
-    Optional<string> PlatformName { get; }
+    string? PlatformName { get; }
 
     /// <summary>
     /// Gets the username on the platform a bot has connected.
     /// </summary>
     /// <remarks>The length of the platform username must be max. 100 characters.</remarks>
-    Optional<string> PlatformUsername { get; }
+    string? PlatformUsername { get; }
 
     /// <summary>
     /// Gets the object mapping of <see cref="IApplicationRoleConnectionMetadata.Key"/> to their stringified value
     /// for the user on the platform a bot has connected.
     /// </summary>
     /// <remarks>The length of the stringified value must max. 100 characters.</remarks>
-    Optional<IReadOnlyDictionary<string, string>> Metadata { get; }
+    IReadOnlyDictionary<string, string> Metadata { get; }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
@@ -331,4 +331,33 @@ public interface IDiscordRestApplicationAPI
         IReadOnlyList<IApplicationCommandPermissions> permissions,
         CancellationToken ct = default
     );
+
+    /// <summary>
+    /// Gets the application role connection metadata records for the given application..
+    /// </summary>
+    /// <param name="applicationID">The ID of the bot application.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>A retrieval result which may or may not have succeeded.</returns>
+    Task<Result<IReadOnlyList<IApplicationRoleConnectionMetadata>>> GetApplicationRoleConnectionMetadataRecordsAsync
+    (
+        Snowflake applicationID,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Updates the application role connection metadata records for the given application..
+    /// </summary>
+    /// <remarks>
+    /// An application can have a maximum of 5 metadata records.
+    /// </remarks>
+    /// <param name="applicationID">The ID of the bot application.</param>
+    /// <param name="records">The metadata records to overwrite the existing ones.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>An creation result which may or may not have succeeded.</returns>
+    Task<Result<IReadOnlyList<IApplicationRoleConnectionMetadata>>> UpdateApplicationRoleConnectionMetadataRecordsAsync
+    (
+        Snowflake applicationID,
+        IReadOnlyList<IApplicationRoleConnectionMetadata> records,
+        CancellationToken ct = default
+    );
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
@@ -353,7 +353,7 @@ public interface IDiscordRestApplicationAPI
     /// <param name="applicationID">The ID of the bot application.</param>
     /// <param name="records">The metadata records to overwrite the existing ones.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
-    /// <returns>An creation result which may or may not have succeeded.</returns>
+    /// <returns>An update result which may or may not have succeeded.</returns>
     Task<Result<IReadOnlyList<IApplicationRoleConnectionMetadata>>> UpdateApplicationRoleConnectionMetadataRecordsAsync
     (
         Snowflake applicationID,

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestUserAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestUserAPI.cs
@@ -130,10 +130,52 @@ public interface IDiscordRestUserAPI
     /// <summary>
     /// Gets a list of connection objects.
     /// </summary>
+    /// <remarks>
+    /// Requires the "connections" OAuth" scope.
+    /// </remarks>
     /// <param name="ct">The cancellation token for this operation.</param>
     /// <returns>A retrieval result which may or may not have succeeded.</returns>
     Task<Result<IReadOnlyList<IConnection>>> GetUserConnectionsAsync
     (
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Gets the application role connection for the user.
+    /// </summary>
+    /// <remarks>
+    /// Requires an OAuth2 access token with role_connections.write scope for the specified <paramref name="applicationID"/>.
+    /// </remarks>
+    /// <param name="applicationID">The ID of the application.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>A retrieval result which may or may not have succeeded.</returns>
+    Task<Result<IApplicationRoleConnection>> GetUserApplicationRoleConnectionAsync
+    (
+        Snowflake applicationID,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Updates and returns the application role connection for the user.
+    /// </summary>
+    /// <remarks>
+    /// Requires an OAuth2 access token with role_connections.write scope for the specified <paramref name="applicationID"/>.
+    /// </remarks>
+    /// <param name="applicationID">The ID of the application.</param>
+    /// <param name="platformName">The vanity name of the platform a bot has connected (max 50 characters).</param>
+    /// <param name="platformUsername">The username on the platform a bot has connected (max 100 characters).</param>
+    /// <param name="metadata">
+    /// The object mapping application role connection metadata keys to their stringified value (max 100 characters) for
+    /// the user on the platform a bot has connected.
+    /// </param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>A retrieval result which may or may not have succeeded.</returns>
+    Task<Result<IApplicationRoleConnection>> UpdateUserApplicationRoleConnectionAsync
+    (
+        Snowflake applicationID,
+        Optional<string> platformName = default,
+        Optional<string> platformUsername = default,
+        Optional<IReadOnlyDictionary<string, string>> metadata = default,
         CancellationToken ct = default
     );
 }

--- a/Backend/Remora.Discord.API/API/Objects/Applications/ApplicationRoleConnectionMetadata.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Applications/ApplicationRoleConnectionMetadata.cs
@@ -1,5 +1,5 @@
 //
-//  Application.cs
+//  ApplicationRoleConnectionMetadata.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -20,39 +20,21 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Rest.Core;
 
-#pragma warning disable CS1591
-
 namespace Remora.Discord.API.Objects;
 
-/// <inheritdoc cref="IApplication" />
+/// <inheritdoc cref="IApplicationRoleConnectionMetadata"/>
 [PublicAPI]
-public record Application
+public record ApplicationRoleConnectionMetadata
 (
-    Snowflake ID,
+    string Key,
     string Name,
-    IImageHash? Icon,
     string Description,
-    Optional<IReadOnlyList<string>> RPCOrigins,
-    bool IsBotPublic,
-    bool DoesBotRequireCodeGrant,
-    Optional<string> TermsOfServiceURL,
-    Optional<string> PrivacyPolicyURL,
-    IPartialUser? Owner,
-    string VerifyKey,
-    ITeam? Team,
-    Optional<Snowflake> GuildID = default,
-    Optional<Snowflake> PrimarySKUID = default,
-    Optional<string> Slug = default,
-    Optional<IImageHash> CoverImage = default,
-    Optional<ApplicationFlags> Flags = default,
-    Optional<IReadOnlyList<string>> Tags = default,
-    Optional<IApplicationInstallParameters> InstallParams = default,
-    Optional<Uri> CustomInstallUrl = default,
-    Optional<Uri> RoleConnectionsVerificationUrl = default
-) : IApplication;
+    ApplicationRoleConnectionMetadataType Type,
+    Optional<IReadOnlyDictionary<string, string>> NameLocalizations = default,
+    Optional<IReadOnlyDictionary<string, string>> DescriptionLocalizations = default
+) : IApplicationRoleConnectionMetadata;

--- a/Backend/Remora.Discord.API/API/Objects/Applications/PartialApplication.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Applications/PartialApplication.cs
@@ -53,5 +53,6 @@ public record PartialApplication
     Optional<ApplicationFlags> Flags = default,
     Optional<IReadOnlyList<string>> Tags = default,
     Optional<IApplicationInstallParameters> InstallParams = default,
-    Optional<Uri> CustomInstallUrl = default
+    Optional<Uri> CustomInstallUrl = default,
+    Optional<Uri> RoleConnectionsVerificationUrl = default
 ) : IPartialApplication;

--- a/Backend/Remora.Discord.API/API/Objects/Users/ApplicationRoleConnection.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Users/ApplicationRoleConnection.cs
@@ -23,7 +23,6 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
-using Remora.Rest.Core;
 
 namespace Remora.Discord.API.Objects;
 
@@ -31,7 +30,7 @@ namespace Remora.Discord.API.Objects;
 [PublicAPI]
 public record ApplicationRoleConnection
 (
-    Optional<string> PlatformName = default,
-    Optional<string> PlatformUsername = default,
-    Optional<IReadOnlyDictionary<string, string>> Metadata = default
+    string? PlatformName,
+    string? PlatformUsername,
+    IReadOnlyDictionary<string, string> Metadata
 ) : IApplicationRoleConnection;

--- a/Backend/Remora.Discord.API/API/Objects/Users/ApplicationRoleConnection.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Users/ApplicationRoleConnection.cs
@@ -1,0 +1,37 @@
+//
+//  ApplicationRoleConnection.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Objects;
+
+/// <inheritdoc cref="IApplicationRoleConnection"/>
+[PublicAPI]
+public record ApplicationRoleConnection
+(
+    Optional<string> PlatformName = default,
+    Optional<string> PlatformUsername = default,
+    Optional<IReadOnlyDictionary<string, string>> Metadata = default
+) : IApplicationRoleConnection;

--- a/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
@@ -110,7 +110,8 @@ public static class ServiceCollectionExtensions
                         .AddOAuth2ObjectConverters()
                         .AddTeamObjectConverters()
                         .AddStageInstanceObjectConverters()
-                        .AddStickerObjectConverters();
+                        .AddStickerObjectConverters()
+                        .AddApplicationRoleConnectionObjectConverters();
 
                     options.AddDataObjectConverter<IUnknownEvent, UnknownEvent>();
                     options.AddConverter<PropertyErrorDetailsConverter>();
@@ -1123,6 +1124,21 @@ public static class ServiceCollectionExtensions
             .WithPropertyName(s => s.SKUID, "sku_id");
 
         options.AddDataObjectConverter<INitroStickerPacks, NitroStickerPacks>();
+
+        return options;
+    }
+
+    /// <summary>
+    /// Adds the JSON converters that handle application role connection objects.
+    /// </summary>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The options, with the converters added.</returns>
+    private static JsonSerializerOptions AddApplicationRoleConnectionObjectConverters
+    (
+        this JsonSerializerOptions options
+    )
+    {
+        options.AddDataObjectConverter<IApplicationRoleConnectionMetadata, ApplicationRoleConnectionMetadata>();
 
         return options;
     }

--- a/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
@@ -1139,6 +1139,7 @@ public static class ServiceCollectionExtensions
     )
     {
         options.AddDataObjectConverter<IApplicationRoleConnectionMetadata, ApplicationRoleConnectionMetadata>();
+        options.AddDataObjectConverter<IApplicationRoleConnection, ApplicationRoleConnection>();
 
         return options;
     }

--- a/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
@@ -1133,10 +1133,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="options">The serializer options.</param>
     /// <returns>The options, with the converters added.</returns>
-    private static JsonSerializerOptions AddApplicationRoleConnectionObjectConverters
-    (
-        this JsonSerializerOptions options
-    )
+    private static JsonSerializerOptions AddApplicationRoleConnectionObjectConverters(this JsonSerializerOptions options)
     {
         options.AddDataObjectConverter<IApplicationRoleConnectionMetadata, ApplicationRoleConnectionMetadata>();
         options.AddDataObjectConverter<IApplicationRoleConnection, ApplicationRoleConnection>();

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestUserAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestUserAPI.cs
@@ -265,6 +265,7 @@ public partial class CachingDiscordRestUserAPI : IDiscordRestUserAPI, IRestCusto
             applicationID,
             ct
         );
+
         if (!getUserApplicationRoleConnection.IsDefined(out var userApplicationRoleConnection))
         {
             return getUserApplicationRoleConnection;

--- a/Backend/Remora.Discord.Caching/KeyHelpers.cs
+++ b/Backend/Remora.Discord.Caching/KeyHelpers.cs
@@ -299,6 +299,16 @@ public static class KeyHelpers
     }
 
     /// <summary>
+    /// Creates a cache key for an <see cref="IApplicationRoleConnection" /> instance of the current <see cref="IUser"/> instance.
+    /// </summary>
+    /// <param name="applicationID">The ID of the application.</param>
+    /// <returns>The cache key.</returns>
+    public static string CreateCurrentUserApplicationRoleConnectionCacheKey(in Snowflake applicationID)
+    {
+        return $"{CreateCurrentUserCacheKey()}:Application:{applicationID}:RoleConnection";
+    }
+
+    /// <summary>
     /// Creates a cache key for an <see cref="IConnection"/> instance.
     /// </summary>
     /// <param name="connectionID">The ID of the connection.</param>

--- a/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
@@ -589,30 +589,30 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
         CancellationToken ct = default
     )
     {
-        if (records.Any(r => r.Key.Length is < 1 or > 50))
+        if (records.Any(r => r.Key.Length > 50))
         {
             return new ArgumentOutOfRangeError
             (
                 nameof(records),
-                "Role connection metadata keys must be between 1 and 50 characters."
+                "Role connection metadata keys must be max. 50 characters."
             );
         }
 
-        if (records.Any(r => r.Name.Length is < 1 or > 100))
+        if (records.Any(r => r.Name.Length > 100))
         {
             return new ArgumentOutOfRangeError
             (
                 nameof(records),
-                "Role connection metadata names must be between 1 and 100 characters."
+                "Role connection metadata names must be max. 100 characters."
             );
         }
 
-        if (records.Any(r => r.Description.Length is < 1 or > 200))
+        if (records.Any(r => r.Description.Length > 200))
         {
             return new ArgumentOutOfRangeError
             (
                 nameof(records),
-                "Role connection metadata descriptions must be between 1 and 200 characters."
+                "Role connection metadata descriptions must be max. 200 characters."
             );
         }
 

--- a/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
@@ -565,4 +565,64 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
             ct: ct
         );
     }
+
+    /// <inheritdoc />
+    public virtual Task<Result<IReadOnlyList<IApplicationRoleConnectionMetadata>>> GetApplicationRoleConnectionMetadataRecordsAsync
+    (
+        Snowflake applicationID,
+        CancellationToken ct = default
+    )
+    {
+        return this.RestHttpClient.GetAsync<IReadOnlyList<IApplicationRoleConnectionMetadata>>
+        (
+            $"applications/{applicationID}/role-connections/metadata",
+            b => b.WithRateLimitContext(this.RateLimitCache),
+            ct: ct
+        );
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<Result<IReadOnlyList<IApplicationRoleConnectionMetadata>>> UpdateApplicationRoleConnectionMetadataRecordsAsync
+    (
+        Snowflake applicationID,
+        IReadOnlyList<IApplicationRoleConnectionMetadata> records,
+        CancellationToken ct = default
+    )
+    {
+        if (records.Any(r => r.Key.Length is < 1 or > 50))
+        {
+            return new ArgumentOutOfRangeError
+            (
+                nameof(records),
+                "Role connection metadata keys must be between 1 and 50 characters."
+            );
+        }
+
+        if (records.Any(r => r.Name.Length is < 1 or > 100))
+        {
+            return new ArgumentOutOfRangeError
+            (
+                nameof(records),
+                "Role connection metadata names must be between 1 and 100 characters."
+            );
+        }
+
+        if (records.Any(r => r.Description.Length is < 1 or > 200))
+        {
+            return new ArgumentOutOfRangeError
+            (
+                nameof(records),
+                "Role connection metadata descriptions must be between 1 and 200 characters."
+            );
+        }
+
+        return await this.RestHttpClient.PutAsync<IReadOnlyList<IApplicationRoleConnectionMetadata>>
+        (
+            $"applications/{applicationID}/role-connections/metadata",
+            b => b
+                .WithJsonArray(json => JsonSerializer.Serialize(json, records, this.JsonOptions), false)
+                .WithRateLimitContext(this.RateLimitCache),
+            ct: ct
+        );
+    }
 }

--- a/Tests/Remora.Discord.API.Tests/API/Objects/ApplicationRoleConnections/ApplicationRoleConnectionMetadataTests.cs
+++ b/Tests/Remora.Discord.API.Tests/API/Objects/ApplicationRoleConnections/ApplicationRoleConnectionMetadataTests.cs
@@ -1,0 +1,39 @@
+//
+//  ApplicationRoleConnectionMetadataTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Tests.TestBases;
+
+namespace Remora.Discord.API.Tests.Objects;
+
+/// <inheritdoc />
+public class ApplicationRoleConnectionMetadataTests : ObjectTestBase<IApplicationRoleConnectionMetadata>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationRoleConnectionMetadataTests"/> class.
+    /// </summary>
+    /// <param name="fixture">The test fixture.</param>
+    public ApplicationRoleConnectionMetadataTests(JsonBackedTypeTestFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/Tests/Remora.Discord.API.Tests/API/Objects/Users/ApplicationRoleConnectionTests.cs
+++ b/Tests/Remora.Discord.API.Tests/API/Objects/Users/ApplicationRoleConnectionTests.cs
@@ -1,0 +1,39 @@
+//
+//  ApplicationRoleConnectionTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Tests.TestBases;
+
+namespace Remora.Discord.API.Tests.Objects;
+
+/// <inheritdoc />
+public class ApplicationRoleConnectionTests : ObjectTestBase<IApplicationRoleConnection>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationRoleConnectionTests"/> class.
+    /// </summary>
+    /// <param name="fixture">The test fixture.</param>
+    public ApplicationRoleConnectionTests(JsonBackedTypeTestFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
@@ -2092,4 +2092,342 @@ public class DiscordRestApplicationAPITests
             ResultAssert.Successful(result);
         }
     }
+
+    /// <summary>
+    /// Tests the <see cref="DiscordRestApplicationAPI.GetApplicationRoleConnectionMetadataRecordsAsync"/> method.
+    /// </summary>
+    public class GetApplicationRoleConnectionMetadataRecordsAsync : RestAPITestBase<IDiscordRestApplicationAPI>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetApplicationRoleConnectionMetadataRecordsAsync"/> class.
+        /// </summary>
+        /// <param name="fixture">The test fixture.</param>
+        public GetApplicationRoleConnectionMetadataRecordsAsync(RestAPITestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        /// <summary>
+        /// Tests whether the API method performs its request correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task PerformsRequestCorrectly()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Get, $"{Constants.BaseURL}applications/{applicationID}/role-connections/metadata")
+                    .WithNoContent()
+                    .Respond("application/json", "[ ]")
+            );
+
+            var result = await api.GetApplicationRoleConnectionMetadataRecordsAsync
+            (
+                applicationID
+            );
+
+            ResultAssert.Successful(result);
+        }
+    }
+
+    /// <summary>
+    /// Tests the <see cref="DiscordRestApplicationAPI.UpdateApplicationRoleConnectionMetadataRecordsAsync"/> method.
+    /// </summary>
+    public class UpdateApplicationRoleConnectionMetadataRecordsAsync : RestAPITestBase<IDiscordRestApplicationAPI>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateApplicationRoleConnectionMetadataRecordsAsync"/> class.
+        /// </summary>
+        /// <param name="fixture">The test fixture.</param>
+        public UpdateApplicationRoleConnectionMetadataRecordsAsync(RestAPITestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        /// <summary>
+        /// Tests whether the API method performs its request correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task PerformsRequestCorrectly()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+            var records = new[]
+            {
+                new ApplicationRoleConnectionMetadata
+                (
+                    "a",
+                    "b",
+                    "c",
+                    ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
+                ),
+                new ApplicationRoleConnectionMetadata
+                (
+                    new string('d', 50),
+                    new string('e', 100),
+                    new string('f', 200),
+                    ApplicationRoleConnectionMetadataType.IntegerGreaterThanOrEqual
+                )
+            };
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}applications/{applicationID}/role-connections/metadata")
+                    .WithJson
+                    (
+                        json => json.IsArray
+                        (
+                            a => a
+                                .WithElement
+                                (
+                                    0,
+                                    e => e.IsObject
+                                    (
+                                        o => o
+                                            .WithProperty("key", p => p.Is(records[0].Key))
+                                            .WithProperty("name", p => p.Is(records[0].Name))
+                                            .WithProperty("description", p => p.Is(records[0].Description))
+                                            .WithProperty("type", p => p.Is((int)records[0].Type))
+                                    )
+                                )
+                                .WithElement
+                                (
+                                    1,
+                                    e => e.IsObject
+                                    (
+                                        o => o
+                                            .WithProperty("key", p => p.Is(records[1].Key))
+                                            .WithProperty("name", p => p.Is(records[1].Name))
+                                            .WithProperty("description", p => p.Is(records[1].Description))
+                                            .WithProperty("type", p => p.Is((int)records[1].Type))
+                                    )
+                                )
+                        )
+                    )
+                    .Respond("application/json", "[]")
+            );
+
+            var result = await api.UpdateApplicationRoleConnectionMetadataRecordsAsync
+            (
+                applicationID,
+                records
+            );
+
+            ResultAssert.Successful(result);
+        }
+
+        /// <summary>
+        /// Tests whether the API method returns a client-side error if a failure condition is met.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task ReturnsUnsuccessfulIfKeyIsTooShort()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+            var records = new[]
+            {
+                new ApplicationRoleConnectionMetadata
+                (
+                    string.Empty,
+                    "b",
+                    "c",
+                    ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
+                )
+            };
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}applications/{applicationID}/role-connections/metadata")
+                    .Respond("application/json", $"[ {SampleRepository.Samples[typeof(IApplicationRoleConnectionMetadata)]} ]")
+            );
+
+            var result = await api.UpdateApplicationRoleConnectionMetadataRecordsAsync
+            (
+                applicationID,
+                records
+            );
+
+            ResultAssert.Unsuccessful(result);
+        }
+
+        /// <summary>
+        /// Tests whether the API method returns a client-side error if a failure condition is met.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task ReturnsUnsuccessfulIfKeyIsTooLong()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+            var records = new[]
+            {
+                new ApplicationRoleConnectionMetadata
+                (
+                    new string('a', 51),
+                    "b",
+                    "c",
+                    ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
+                )
+            };
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}applications/{applicationID}/role-connections/metadata")
+                    .Respond("application/json", $"[ {SampleRepository.Samples[typeof(IApplicationRoleConnectionMetadata)]} ]")
+            );
+
+            var result = await api.UpdateApplicationRoleConnectionMetadataRecordsAsync
+            (
+                applicationID,
+                records
+            );
+
+            ResultAssert.Unsuccessful(result);
+        }
+
+        /// <summary>
+        /// Tests whether the API method returns a client-side error if a failure condition is met.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task ReturnsUnsuccessfulIfNameIsTooShort()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+            var records = new[]
+            {
+                new ApplicationRoleConnectionMetadata
+                (
+                    "a",
+                    string.Empty,
+                    "c",
+                    ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
+                )
+            };
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}applications/{applicationID}/role-connections/metadata")
+                    .Respond("application/json", $"[ {SampleRepository.Samples[typeof(IApplicationRoleConnectionMetadata)]} ]")
+            );
+
+            var result = await api.UpdateApplicationRoleConnectionMetadataRecordsAsync
+            (
+                applicationID,
+                records
+            );
+
+            ResultAssert.Unsuccessful(result);
+        }
+
+        /// <summary>
+        /// Tests whether the API method returns a client-side error if a failure condition is met.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task ReturnsUnsuccessfulIfNameIsTooLong()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+            var records = new[]
+            {
+                new ApplicationRoleConnectionMetadata
+                (
+                    "a",
+                    new string('b', 101),
+                    "c",
+                    ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
+                )
+            };
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}applications/{applicationID}/role-connections/metadata")
+                    .Respond("application/json", $"[ {SampleRepository.Samples[typeof(IApplicationRoleConnectionMetadata)]} ]")
+            );
+
+            var result = await api.UpdateApplicationRoleConnectionMetadataRecordsAsync
+            (
+                applicationID,
+                records
+            );
+
+            ResultAssert.Unsuccessful(result);
+        }
+
+        /// <summary>
+        /// Tests whether the API method returns a client-side error if a failure condition is met.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task ReturnsUnsuccessfulIfDescriptionIsTooShort()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+            var records = new[]
+            {
+                new ApplicationRoleConnectionMetadata
+                (
+                    "a",
+                    "b",
+                    string.Empty,
+                    ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
+                )
+            };
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}applications/{applicationID}/role-connections/metadata")
+                    .Respond("application/json", $"[ {SampleRepository.Samples[typeof(IApplicationRoleConnectionMetadata)]} ]")
+            );
+
+            var result = await api.UpdateApplicationRoleConnectionMetadataRecordsAsync
+            (
+                applicationID,
+                records
+            );
+
+            ResultAssert.Unsuccessful(result);
+        }
+
+        /// <summary>
+        /// Tests whether the API method returns a client-side error if a failure condition is met.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task ReturnsUnsuccessfulIfDescriptionIsTooLong()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+            var records = new[]
+            {
+                new ApplicationRoleConnectionMetadata
+                (
+                    "a",
+                    "b",
+                    new string('c', 201),
+                    ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
+                )
+            };
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}applications/{applicationID}/role-connections/metadata")
+                    .Respond("application/json", $"[ {SampleRepository.Samples[typeof(IApplicationRoleConnectionMetadata)]} ]")
+            );
+
+            var result = await api.UpdateApplicationRoleConnectionMetadataRecordsAsync
+            (
+                applicationID,
+                records
+            );
+
+            ResultAssert.Unsuccessful(result);
+        }
+    }
 }

--- a/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
@@ -2159,9 +2159,9 @@ public class DiscordRestApplicationAPITests
             {
                 new ApplicationRoleConnectionMetadata
                 (
-                    "a",
-                    "b",
-                    "c",
+                    string.Empty,
+                    string.Empty,
+                    string.Empty,
                     ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
                 ),
                 new ApplicationRoleConnectionMetadata
@@ -2225,41 +2225,6 @@ public class DiscordRestApplicationAPITests
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
         [Fact]
-        public async Task ReturnsUnsuccessfulIfKeyIsTooShort()
-        {
-            var applicationID = DiscordSnowflake.New(0);
-            var records = new[]
-            {
-                new ApplicationRoleConnectionMetadata
-                (
-                    string.Empty,
-                    "b",
-                    "c",
-                    ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
-                )
-            };
-
-            var api = CreateAPI
-            (
-                b => b
-                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}applications/{applicationID}/role-connections/metadata")
-                    .Respond("application/json", $"[ {SampleRepository.Samples[typeof(IApplicationRoleConnectionMetadata)]} ]")
-            );
-
-            var result = await api.UpdateApplicationRoleConnectionMetadataRecordsAsync
-            (
-                applicationID,
-                records
-            );
-
-            ResultAssert.Unsuccessful(result);
-        }
-
-        /// <summary>
-        /// Tests whether the API method returns a client-side error if a failure condition is met.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        [Fact]
         public async Task ReturnsUnsuccessfulIfKeyIsTooLong()
         {
             var applicationID = DiscordSnowflake.New(0);
@@ -2268,43 +2233,8 @@ public class DiscordRestApplicationAPITests
                 new ApplicationRoleConnectionMetadata
                 (
                     new string('a', 51),
-                    "b",
-                    "c",
-                    ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
-                )
-            };
-
-            var api = CreateAPI
-            (
-                b => b
-                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}applications/{applicationID}/role-connections/metadata")
-                    .Respond("application/json", $"[ {SampleRepository.Samples[typeof(IApplicationRoleConnectionMetadata)]} ]")
-            );
-
-            var result = await api.UpdateApplicationRoleConnectionMetadataRecordsAsync
-            (
-                applicationID,
-                records
-            );
-
-            ResultAssert.Unsuccessful(result);
-        }
-
-        /// <summary>
-        /// Tests whether the API method returns a client-side error if a failure condition is met.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        [Fact]
-        public async Task ReturnsUnsuccessfulIfNameIsTooShort()
-        {
-            var applicationID = DiscordSnowflake.New(0);
-            var records = new[]
-            {
-                new ApplicationRoleConnectionMetadata
-                (
-                    "a",
                     string.Empty,
-                    "c",
+                    string.Empty,
                     ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
                 )
             };
@@ -2337,43 +2267,8 @@ public class DiscordRestApplicationAPITests
             {
                 new ApplicationRoleConnectionMetadata
                 (
-                    "a",
+                    string.Empty,
                     new string('b', 101),
-                    "c",
-                    ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
-                )
-            };
-
-            var api = CreateAPI
-            (
-                b => b
-                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}applications/{applicationID}/role-connections/metadata")
-                    .Respond("application/json", $"[ {SampleRepository.Samples[typeof(IApplicationRoleConnectionMetadata)]} ]")
-            );
-
-            var result = await api.UpdateApplicationRoleConnectionMetadataRecordsAsync
-            (
-                applicationID,
-                records
-            );
-
-            ResultAssert.Unsuccessful(result);
-        }
-
-        /// <summary>
-        /// Tests whether the API method returns a client-side error if a failure condition is met.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        [Fact]
-        public async Task ReturnsUnsuccessfulIfDescriptionIsTooShort()
-        {
-            var applicationID = DiscordSnowflake.New(0);
-            var records = new[]
-            {
-                new ApplicationRoleConnectionMetadata
-                (
-                    "a",
-                    "b",
                     string.Empty,
                     ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
                 )
@@ -2407,8 +2302,8 @@ public class DiscordRestApplicationAPITests
             {
                 new ApplicationRoleConnectionMetadata
                 (
-                    "a",
-                    "b",
+                    string.Empty,
+                    string.Empty,
                     new string('c', 201),
                     ApplicationRoleConnectionMetadataType.IntegerLessThanOrEqual
                 )

--- a/Tests/Remora.Discord.Rest.Tests/API/Users/DiscordRestUserAPITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/Users/DiscordRestUserAPITests.cs
@@ -479,4 +479,206 @@ public class DiscordRestUserAPITests
             ResultAssert.Successful(result);
         }
     }
+
+    /// <summary>
+    /// Tests the <see cref="DiscordRestUserAPI.GetUserApplicationRoleConnectionAsync"/> method.
+    /// </summary>
+    public class GetUserApplicationRoleConnectionAsync : RestAPITestBase<IDiscordRestUserAPI>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetUserApplicationRoleConnectionAsync"/> class.
+        /// </summary>
+        /// <param name="fixture">The test fixture.</param>
+        public GetUserApplicationRoleConnectionAsync(RestAPITestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        /// <summary>
+        /// Tests whether the API method performs its request correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task PerformsRequestCorrectly()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Get, $"{Constants.BaseURL}users/@me/applications/{applicationID}/role-connection")
+                    .Respond("application/json", SampleRepository.Samples[typeof(IApplicationRoleConnection)])
+            );
+
+            var result = await api.GetUserApplicationRoleConnectionAsync(applicationID);
+            ResultAssert.Successful(result);
+        }
+    }
+
+    /// <summary>
+    /// Tests the <see cref="DiscordRestUserAPI.GetUserApplicationRoleConnectionAsync"/> method.
+    /// </summary>
+    public class UpdateUserApplicationRoleConnectionAsync : RestAPITestBase<IDiscordRestUserAPI>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateUserApplicationRoleConnectionAsync"/> class.
+        /// </summary>
+        /// <param name="fixture">The test fixture.</param>
+        public UpdateUserApplicationRoleConnectionAsync(RestAPITestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        /// <summary>
+        /// Tests whether the API method performs its request correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task PerformsRequestCorrectly()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+            var platformName = string.Empty;
+            var platformUsername = string.Empty;
+            var metadata = new Dictionary<string, string>
+            {
+                { "a", string.Empty },
+                { "b", new string('1', 100) }
+            };
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}users/@me/applications/{applicationID}/role-connection")
+                    .WithJson
+                    (
+                        json => json.IsObject
+                        (
+                            o => o
+                                .WithProperty("platform_name", p => p.Is(platformName))
+                                .WithProperty("platform_username", p => p.Is(platformUsername))
+                                .WithProperty
+                                (
+                                    "metadata",
+                                    p => p.IsObject
+                                    (
+                                        m =>
+                                        {
+                                            foreach (var metaPair in metadata)
+                                            {
+                                                m.WithProperty(metaPair.Key, p => p.Is(metaPair.Value));
+                                            }
+                                        }
+                                    )
+                                )
+                        )
+                    )
+                    .Respond("application/json", SampleRepository.Samples[typeof(IApplicationRoleConnection)])
+            );
+
+            var result = await api.UpdateUserApplicationRoleConnectionAsync
+            (
+                applicationID,
+                platformName,
+                platformUsername,
+                metadata
+            );
+            ResultAssert.Successful(result);
+        }
+
+        /// <summary>
+        /// Tests whether the API method performs its request correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task ReturnsUnsuccessfulIfPlatformNameIsTooLong()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+            var platformName = new string('a', 51);
+            var platformUsername = string.Empty;
+            var metadata = new Dictionary<string, string>
+            {
+                { "a", "true" }
+            };
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}users/@me/applications/{applicationID}/role-connection")
+                    .Respond("application/json", SampleRepository.Samples[typeof(IApplicationRoleConnection)])
+            );
+
+            var result = await api.UpdateUserApplicationRoleConnectionAsync
+            (
+                applicationID,
+                platformName,
+                platformUsername,
+                metadata
+            );
+            ResultAssert.Unsuccessful(result);
+        }
+
+        /// <summary>
+        /// Tests whether the API method performs its request correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task ReturnsUnsuccessfulIfPlatformUsernameIsTooLong()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+            var platformName = string.Empty;
+            var platformUsername = new string('a', 101);
+            var metadata = new Dictionary<string, string>
+            {
+                { "a", "true" }
+            };
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}users/@me/applications/{applicationID}/role-connection")
+                    .Respond("application/json", SampleRepository.Samples[typeof(IApplicationRoleConnection)])
+            );
+
+            var result = await api.UpdateUserApplicationRoleConnectionAsync
+            (
+                applicationID,
+                platformName,
+                platformUsername,
+                metadata
+            );
+            ResultAssert.Unsuccessful(result);
+        }
+
+        /// <summary>
+        /// Tests whether the API method performs its request correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task ReturnsUnsuccessfulIfMetadataValueIsTooLong()
+        {
+            var applicationID = DiscordSnowflake.New(0);
+            var platformName = string.Empty;
+            var platformUsername = string.Empty;
+            var metadata = new Dictionary<string, string>
+            {
+                { "a", new string('1', 101) }
+            };
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Put, $"{Constants.BaseURL}users/@me/applications/{applicationID}/role-connection")
+                    .Respond("application/json", SampleRepository.Samples[typeof(IApplicationRoleConnection)])
+            );
+
+            var result = await api.UpdateUserApplicationRoleConnectionAsync
+            (
+                applicationID,
+                platformName,
+                platformUsername,
+                metadata
+            );
+            ResultAssert.Unsuccessful(result);
+        }
+    }
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/APPLICATION_ROLE_CONNECTION/APPLICATION_ROLE_CONNECTION.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/APPLICATION_ROLE_CONNECTION/APPLICATION_ROLE_CONNECTION.json
@@ -1,0 +1,7 @@
+{
+  "platform_name": "none",
+  "platform_username": "none",
+  "metadata": {
+    "dummy": "none"
+  }
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/APPLICATION_ROLE_CONNECTION_METADATA/APPLICATION_ROLE_CONNECTION_METADATA.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/APPLICATION_ROLE_CONNECTION_METADATA/APPLICATION_ROLE_CONNECTION_METADATA.json
@@ -1,0 +1,6 @@
+{
+  "type": 1,
+  "key": "none",
+  "name": "none",
+  "description": "none"
+}


### PR DESCRIPTION
This PR implements the new application role connections endpoints and objects as documented in https://github.com/discord/discord-api-docs/pull/5668