### PR TITLE
Add overload of AddDiscordService for use with HostApplicationBuilder

### DIFF
--- a/Remora.Discord.Hosting/Extensions/HostBuilderExtensions.cs
+++ b/Remora.Discord.Hosting/Extensions/HostBuilderExtensions.cs
@@ -39,12 +39,12 @@ namespace Remora.Discord.Hosting.Extensions;
 public static class HostBuilderExtensions
 {
     /// <summary>
-    /// Adds the required services for Remora Discord and a <see cref="IHostedService"/> implementation.
+    /// Adds the required services for Remora Discord to an <see cref="IHostBuilder"/>.
     /// </summary>
     /// <param name="hostBuilder">The host builder.</param>
     /// <param name="tokenFactory">A function that retrieves the bot token.</param>
     /// <param name="buildClient">Extra options to configure the rest client.</param>
-    /// <returns>The service collection, with the services added.</returns>
+    /// <returns>The host builder, with the services added.</returns>
     public static IHostBuilder AddDiscordService(this IHostBuilder hostBuilder, Func<IServiceProvider, string> tokenFactory, Action<IHttpClientBuilder>? buildClient = null)
     {
         hostBuilder.ConfigureServices((_, serviceCollection) =>
@@ -63,5 +63,29 @@ public static class HostBuilderExtensions
         });
 
         return hostBuilder;
+    }
+
+    /// <summary>
+    /// Adds the required services for Remora Discord to an <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="serviceCollection">The service collection.</param>
+    /// <param name="tokenFactory">A function that retrieves the bot token.</param>
+    /// <param name="buildClient">Extra options to configure the rest client.</param>
+    /// <returns>The service collection, with the services added.</returns>
+    public static IServiceCollection AddDiscordService(this IServiceCollection serviceCollection, Func<IServiceProvider, string> tokenFactory, Action<IHttpClientBuilder>? buildClient = null)
+    {
+        serviceCollection.Configure(() => new DiscordServiceOptions());
+
+        serviceCollection
+            .AddDiscordGateway(tokenFactory, buildClient);
+
+        serviceCollection
+            .TryAddSingleton<DiscordService>();
+
+        serviceCollection
+            .AddSingleton<IHostedService, DiscordService>(serviceProvider =>
+                serviceProvider.GetRequiredService<DiscordService>());
+
+        return serviceCollection;
     }
 }

--- a/Remora.Discord.Hosting/Extensions/HostBuilderExtensions.cs
+++ b/Remora.Discord.Hosting/Extensions/HostBuilderExtensions.cs
@@ -48,19 +48,7 @@ public static class HostBuilderExtensions
     public static IHostBuilder AddDiscordService(this IHostBuilder hostBuilder, Func<IServiceProvider, string> tokenFactory, Action<IHttpClientBuilder>? buildClient = null)
     {
         hostBuilder.ConfigureServices((_, serviceCollection) =>
-        {
-            serviceCollection.Configure(() => new DiscordServiceOptions());
-
-            serviceCollection
-                .AddDiscordGateway(tokenFactory, buildClient);
-
-            serviceCollection
-                .TryAddSingleton<DiscordService>();
-
-            serviceCollection
-                .AddSingleton<IHostedService, DiscordService>(serviceProvider =>
-                    serviceProvider.GetRequiredService<DiscordService>());
-        });
+            serviceCollection.AddDiscordService(tokenFactory, buildClient));
 
         return hostBuilder;
     }

--- a/Remora.Discord.Hosting/Extensions/HostBuilderExtensions.cs
+++ b/Remora.Discord.Hosting/Extensions/HostBuilderExtensions.cs
@@ -39,7 +39,7 @@ namespace Remora.Discord.Hosting.Extensions;
 public static class HostBuilderExtensions
 {
     /// <summary>
-    /// Adds the required services for Remora Discord to an <see cref="IHostBuilder"/>.
+    /// Adds the required services for Remora Discord and a <see cref="IHostedService"/> implementation to an <see cref="IHostBuilder"/>.
     /// </summary>
     /// <param name="hostBuilder">The host builder.</param>
     /// <param name="tokenFactory">A function that retrieves the bot token.</param>
@@ -54,7 +54,7 @@ public static class HostBuilderExtensions
     }
 
     /// <summary>
-    /// Adds the required services for Remora Discord to an <see cref="IServiceCollection"/>.
+    /// Adds the required services for Remora Discord and a <see cref="IHostedService"/> implementation to an <see cref="IServiceCollection"/>.
     /// </summary>
     /// <param name="serviceCollection">The service collection.</param>
     /// <param name="tokenFactory">A function that retrieves the bot token.</param>


### PR DESCRIPTION
.NET 7 adds a new `HostApplicationBuilder` API in the style of the simplified `WebApplicationBuilder` from ASP.NET Core 6. It does not implement `IHostBuilder`, so the existing extension that adds the Remora hosted service does not work with it. The recommended pattern for `HostApplicationBuiler` is to add an extension method for `IServiceCollection` (`builder.Services.AddDiscordService(...)`).
