### PR TITLE
Readd AddDiscordCaching call to Caching sample

### DIFF
--- a/Samples/Caching/Program.cs
+++ b/Samples/Caching/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Caching.Extensions;
 using Remora.Discord.Caching.Services;
 using Remora.Discord.Hosting.Extensions;
 
@@ -52,6 +53,7 @@ public static class Program
         (
             (_, services) =>
             {
+                services.AddDiscordCaching();
                 services.Configure<CacheSettings>(settings =>
                 {
                     // Set the total time for an object to remain in the cache by default.


### PR DESCRIPTION
The AddDiscordCaching call was erroneously when it was first replaced by AddDiscordRedisCaching and the removed when removing the dependency of Redis.