### PR TITLE
Handle IPartial* correctly when updating slash commands

### DIFF
--- a/Remora.Discord.Commands/Extensions/ParameterShapeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/ParameterShapeExtensions.cs
@@ -69,13 +69,13 @@ public static class ParameterShapeExtensions
         return shape.GetActualParameterType() switch
         {
             var t when t == typeof(bool) => ApplicationCommandOptionType.Boolean,
-            var t when t == typeof(IRole) => Role,
-            var t when t == typeof(IUser) => User,
-            var t when t == typeof(IGuildMember) => User,
-            var t when t == typeof(IChannel) => Channel,
+            var t when typeof(IPartialRole).IsAssignableFrom(t) => Role,
+            var t when typeof(IPartialUser).IsAssignableFrom(t) => User,
+            var t when typeof(IPartialGuildMember).IsAssignableFrom(t) => User,
+            var t when typeof(IPartialChannel).IsAssignableFrom(t) => Channel,
             var t when t.IsInteger() => Integer,
             var t when t.IsFloatingPoint() => Number,
-            var t when t == typeof(IAttachment) => Attachment,
+            var t when typeof(IPartialAttachment).IsAssignableFrom(t) => Attachment,
             _ => ApplicationCommandOptionType.String
         };
     }

--- a/Tests/Remora.Discord.Commands.Tests/Extensions/ParameterShapeExtensionsTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Extensions/ParameterShapeExtensionsTests.cs
@@ -1,0 +1,149 @@
+//
+//  ParameterShapeExtensionsTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Reflection;
+using Moq;
+using Remora.Commands.Signatures;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Commands.Attributes;
+using Remora.Discord.Commands.Extensions;
+using Remora.Rest.Core;
+using Xunit;
+
+namespace Remora.Discord.Commands.Tests.Extensions;
+
+/// <summary>
+/// Tests the <see cref="ParameterShapeExtensions"/> class.
+/// </summary>
+public class ParameterShapeExtensionsTests
+{
+    /// <summary>
+    /// Tests the <see cref="ParameterShapeExtensions.GetActualParameterType"/> method.
+    /// </summary>
+    public class GetActualParameterType
+    {
+        /// <summary>
+        /// Tests whether the method performs as expected in multiple cases.
+        /// </summary>
+        /// <param name="parameterType">The parameter type.</param>
+        /// <param name="expectedResult">The expected result.</param>
+        [InlineData(typeof(Optional<int>), typeof(int))]
+        [InlineData(typeof(int?), typeof(int))]
+        [Theory]
+        public void ReturnsCorrectly(Type parameterType, Type expectedResult)
+        {
+            var parameterInfoMock = new Mock<ParameterInfo>();
+            var parameterShapeMock = new Mock<IParameterShape>();
+
+            parameterInfoMock.SetupGet(p => p.ParameterType).Returns(parameterType);
+            parameterShapeMock.SetupGet(p => p.Parameter).Returns(parameterInfoMock.Object);
+
+            Assert.Equal(expectedResult, parameterShapeMock.Object.GetActualParameterType());
+        }
+    }
+
+    /// <summary>
+    /// Tests the <see cref="ParameterShapeExtensions.GetDiscordType"/> method.
+    /// </summary>
+    public class GetDiscordType
+    {
+        /// <summary>
+        /// Tests whether the method performs as expected in multiple cases.
+        /// </summary>
+        /// <param name="parameterType">The parameter type.</param>
+        /// <param name="expectedResult">The expected result.</param>
+        [InlineData(typeof(bool), ApplicationCommandOptionType.Boolean)]
+        [InlineData(typeof(byte), ApplicationCommandOptionType.Integer)]
+        [InlineData(typeof(sbyte), ApplicationCommandOptionType.Integer)]
+        [InlineData(typeof(ushort), ApplicationCommandOptionType.Integer)]
+        [InlineData(typeof(short), ApplicationCommandOptionType.Integer)]
+        [InlineData(typeof(uint), ApplicationCommandOptionType.Integer)]
+        [InlineData(typeof(int), ApplicationCommandOptionType.Integer)]
+        [InlineData(typeof(ulong), ApplicationCommandOptionType.Integer)]
+        [InlineData(typeof(long), ApplicationCommandOptionType.Integer)]
+        [InlineData(typeof(float), ApplicationCommandOptionType.Number)]
+        [InlineData(typeof(double), ApplicationCommandOptionType.Number)]
+        [InlineData(typeof(decimal), ApplicationCommandOptionType.Number)]
+        [InlineData(typeof(string), ApplicationCommandOptionType.String)]
+        [InlineData(typeof(IPartialRole), ApplicationCommandOptionType.Role)]
+        [InlineData(typeof(IRole), ApplicationCommandOptionType.Role)]
+        [InlineData(typeof(IPartialUser), ApplicationCommandOptionType.User)]
+        [InlineData(typeof(IUser), ApplicationCommandOptionType.User)]
+        [InlineData(typeof(IPartialGuildMember), ApplicationCommandOptionType.User)]
+        [InlineData(typeof(IGuildMember), ApplicationCommandOptionType.User)]
+        [InlineData(typeof(IPartialChannel), ApplicationCommandOptionType.Channel)]
+        [InlineData(typeof(IChannel), ApplicationCommandOptionType.Channel)]
+        [InlineData(typeof(IPartialAttachment), ApplicationCommandOptionType.Attachment)]
+        [InlineData(typeof(IAttachment), ApplicationCommandOptionType.Attachment)]
+        [Theory]
+        public void ReturnsWithoutTypeHintAttributeCorrectly(Type parameterType, ApplicationCommandOptionType expectedResult)
+        {
+            var parameterInfoMock = new Mock<ParameterInfo>();
+            var parameterShapeMock = new Mock<IParameterShape>();
+
+            parameterInfoMock.SetupGet(p => p.ParameterType).Returns(parameterType);
+            parameterShapeMock.SetupGet(p => p.Parameter).Returns(parameterInfoMock.Object);
+
+            Assert.Equal(expectedResult, parameterShapeMock.Object.GetDiscordType());
+        }
+
+        /// <summary>
+        /// Tests whether the method performs as expected in multiple cases.
+        /// </summary>
+        /// <param name="parameterType">The parameter type.</param>
+        [InlineData(typeof(bool))]
+        [InlineData(typeof(byte))]
+        [InlineData(typeof(short))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(long))]
+        [InlineData(typeof(float))]
+        [InlineData(typeof(double))]
+        [InlineData(typeof(decimal))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(IPartialRole))]
+        [InlineData(typeof(IPartialUser))]
+        [InlineData(typeof(IPartialGuildMember))]
+        [InlineData(typeof(IPartialChannel))]
+        [InlineData(typeof(IPartialAttachment))]
+        [Theory]
+        public void ReturnsWithTypeHintAttributeCorrectly(Type parameterType)
+        {
+            var parameterInfoMock = new Mock<ParameterInfo>();
+            var parameterShapeMock = new Mock<IParameterShape>();
+
+            parameterInfoMock.Setup(p => p.GetCustomAttributes(typeof(DiscordTypeHintAttribute), false))
+                .Returns
+                (
+                    new object[]
+                    {
+                        new DiscordTypeHintAttribute(TypeHint.String)
+                    }
+                );
+
+            parameterInfoMock.SetupGet(p => p.ParameterType).Returns(parameterType);
+            parameterShapeMock.SetupGet(p => p.Parameter).Returns(parameterInfoMock.Object);
+
+            Assert.Equal(ApplicationCommandOptionType.String, parameterShapeMock.Object.GetDiscordType());
+        }
+    }
+}


### PR DESCRIPTION
With this PR it will allow to also use `IPartial*` inside of command parameters.

I've also took the opportunity to add tests for the `ParameterShapeExtensions`.