### PR TITLE
Don't register interaction groups with assembly-scanning

### DIFF
--- a/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ using Remora.Commands.Groups;
 using Remora.Discord.Extensions.Attributes;
 using Remora.Discord.Gateway.Extensions;
 using Remora.Discord.Gateway.Responders;
+using Remora.Discord.Interactivity;
 
 namespace Remora.Discord.Extensions.Extensions;
 
@@ -56,7 +57,11 @@ public static class ServiceCollectionExtensions
     )
     {
         var candidates = assembly.ExportedTypes
-                                .Where(t => t.IsClass && !t.IsAbstract && typeof(CommandGroup).IsAssignableFrom(t))
+                                .Where(t => t.IsClass &&
+                                            !t.IsAbstract &&
+                                            typeof(CommandGroup).IsAssignableFrom(t) &&
+                                            !typeof(InteractionGroup).IsAssignableFrom(t)
+                                      )
                                 .ToArray();
 
         var tree = serviceCollection.AddCommandTree(treeName);

--- a/Remora.Discord.Extensions/Remora.Discord.Extensions.csproj
+++ b/Remora.Discord.Extensions/Remora.Discord.Extensions.csproj
@@ -12,6 +12,7 @@
         <ProjectReference Include="..\Backend\Remora.Discord.API\Remora.Discord.API.csproj" />
         <ProjectReference Include="..\Backend\Remora.Discord.Gateway\Remora.Discord.Gateway.csproj" />
         <ProjectReference Include="..\Remora.Discord.Commands\Remora.Discord.Commands.csproj" />
+        <ProjectReference Include="..\Remora.Discord.Interactivity\Remora.Discord.Interactivity.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
In the previous PR, there was a bug that was overlooked regarding to the sweeping nature of registering *all* commands.

While technically this was mitigated by the `filter` parameter, this required intiricate knowledge of the implementation of interactivity and action from the user.