### PR TITLE
Fix misnomer in IEmbedImage

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Messages/IEmbedImage.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Messages/IEmbedImage.cs
@@ -32,22 +32,22 @@ namespace Remora.Discord.API.Abstractions.Objects;
 public interface IEmbedImage
 {
     /// <summary>
-    /// Gets the source URL of the thumbnail. Only supports http(s) and attachments.
+    /// Gets the source URL of the image. Only supports http(s) and attachments.
     /// </summary>
     string Url { get; }
 
     /// <summary>
-    /// Gets the proxied URL of the thumbnail.
+    /// Gets the proxied URL of the image.
     /// </summary>
     Optional<string> ProxyUrl { get; }
 
     /// <summary>
-    /// Gets the height of the thumbnail.
+    /// Gets the height of the image.
     /// </summary>
     Optional<int> Height { get; }
 
     /// <summary>
-    /// Gets the width of the thumbnail.
+    /// Gets the width of the image.
     /// </summary>
     Optional<int> Width { get; }
 }


### PR DESCRIPTION
Change "thumbnail" to "image" in the documentation, as it should be.