### PR TITLE
Re-type IMessageComponentData.cs#Values to an optional list of strings

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IMessageComponentData.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IMessageComponentData.cs
@@ -52,5 +52,10 @@ public interface IMessageComponentData
     /// <summary>
     /// Gets the values selected by the user.
     /// </summary>
-    Optional<IReadOnlyList<ISelectOption>> Values { get; }
+    /// <remarks>
+    /// The Discord API docs denote that this field should contain a list of
+    /// <see cref="ISelectOption"/> values. However, in their samples and as
+    /// identified through testing, it actually always contains a list of strings.
+    /// </remarks>
+    Optional<IReadOnlyList<string>> Values { get; }
 }

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/MessageComponentData.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/MessageComponentData.cs
@@ -34,5 +34,5 @@ public record MessageComponentData
     string CustomID,
     ComponentType ComponentType,
     Optional<IApplicationCommandInteractionDataResolved> Resolved,
-    Optional<IReadOnlyList<ISelectOption>> Values
+    Optional<IReadOnlyList<string>> Values
 ) : IMessageComponentData;

--- a/Remora.Discord.Interactivity/Responders/InteractivityResponder.cs
+++ b/Remora.Discord.Interactivity/Responders/InteractivityResponder.cs
@@ -153,7 +153,7 @@ internal sealed class InteractivityResponder : IResponder<IInteractionCreate>
             (
                 new Dictionary<string, IReadOnlyList<string>>
                 {
-                    { "values", data.Values.Value.Select(o => o.Value).ToArray() }
+                    { "values", data.Values.Value }
                 }
             ),
             ComponentType.UserSelect
@@ -189,7 +189,7 @@ internal sealed class InteractivityResponder : IResponder<IInteractionCreate>
         var values = new HashSet<Snowflake>();
         foreach (var value in data.Values.Value)
         {
-            if (DiscordSnowflake.TryParse(value.Value, out var parsed))
+            if (DiscordSnowflake.TryParse(value, out var parsed))
             {
                 values.Add(parsed.Value);
             }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT_DATA/MESSAGE_COMPONENT_DATA.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_COMPONENT_DATA/MESSAGE_COMPONENT_DATA.json
@@ -2,9 +2,6 @@
   "custom_id": "none",
   "component_type": 3,
   "values": [
-    {
-      "label": "none",
-      "value": "none"
-    }
+    "none"
   ]
 }


### PR DESCRIPTION
The Discord API docs denote that this field should contain a list of `ISelectOption` values. However, in their samples and as identified through testing, it actually always contains a list of strings.

I will open a PR on the Discord API docs about this issue in short order, and link it here once done.