### PR TITLE
Interactivity sample updates

### DIFF
--- a/Samples/Interactivity/Interactions/SelectMenuInteractions.cs
+++ b/Samples/Interactivity/Interactions/SelectMenuInteractions.cs
@@ -1,5 +1,5 @@
 //
-//  SPDX-FileName: ColourDropdownInteractions.cs
+//  SPDX-FileName: SelectMenuInteractions.cs
 //  SPDX-FileCopyrightText: Copyright (c) Jarl Gullberg
 //  SPDX-License-Identifier: MIT
 //
@@ -26,21 +26,21 @@ namespace Remora.Discord.Samples.Interactivity.Interactions;
 /// <summary>
 /// Handles colour dropdown interactions.
 /// </summary>
-public partial class ColourDropdownInteractions : InteractionGroup
+public partial class SelectMenuInteractions : InteractionGroup
 {
-    private readonly InteractionCommandContext _context;
+    private readonly IInteractionCommandContext _context;
     private readonly IDiscordRestChannelAPI _channelAPI;
     private readonly FeedbackService _feedback;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ColourDropdownInteractions"/> class.
+    /// Initializes a new instance of the <see cref="SelectMenuInteractions"/> class.
     /// </summary>
     /// <param name="context">The interaction context.</param>
     /// <param name="channelAPI">The channel API.</param>
     /// <param name="feedback">The feedback service.</param>
-    public ColourDropdownInteractions
+    public SelectMenuInteractions
     (
-        InteractionCommandContext context,
+        IInteractionCommandContext context,
         IDiscordRestChannelAPI channelAPI,
         FeedbackService feedback
     )

--- a/Samples/Interactivity/Interactions/StatefulInteractions.cs
+++ b/Samples/Interactivity/Interactions/StatefulInteractions.cs
@@ -16,13 +16,13 @@ namespace Remora.Discord.Samples.Interactivity.Interactions;
 /// </summary>
 public class StatefulInteractions : InteractionGroup
 {
-    private readonly ILogger<ModalInteractions> _log;
+    private readonly ILogger<StatefulInteractions> _log;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StatefulInteractions"/> class.
     /// </summary>
     /// <param name="log">The logging instance for this type.</param>
-    public StatefulInteractions(ILogger<ModalInteractions> log)
+    public StatefulInteractions(ILogger<StatefulInteractions> log)
     {
         _log = log;
     }

--- a/Samples/Interactivity/Program.cs
+++ b/Samples/Interactivity/Program.cs
@@ -100,7 +100,7 @@ public class Program
                         .WithCommandGroup<InteractiveCommands>()
                         .Finish()
                     .AddPagination()
-                    .AddInteractionGroup<ColourDropdownInteractions>()
+                    .AddInteractionGroup<SelectMenuInteractions>()
                     .AddInteractionGroup<ModalInteractions>()
                     .AddInteractionGroup<StatefulInteractions>();
             }


### PR DESCRIPTION
A couple of small updates to the interactivity sample:
- Renamed `ColourDropdownInteractions.cs` to `SelectMenuInteractions.cs`, now that it contains samples for various select menu types.
- Fixed the injection of the interaction context into `SelectMenuInteractions`, by injecting the interface (`IInteractionCommandContext`).
- Injected the correct generic logger type in `StatefulInteractions`.