### PR TITLE
Fix comment on (I)InteractionCommandContext

### DIFF
--- a/Remora.Discord.Commands/Contexts/InteractionCommandContext.cs
+++ b/Remora.Discord.Commands/Contexts/InteractionCommandContext.cs
@@ -27,7 +27,7 @@ using Remora.Discord.API.Abstractions.Objects;
 namespace Remora.Discord.Commands.Contexts;
 
 /// <summary>
-/// Represents contextual information about a currently executing text-based command.
+/// Represents contextual information about a currently executing interaction-based command.
 /// </summary>
 /// <param name="Interaction">The interaction that initiated the command.</param>
 /// <param name="Command">The command associated with the context.</param>

--- a/Remora.Discord.Commands/Contexts/Interfaces/IInteractionCommandContext.cs
+++ b/Remora.Discord.Commands/Contexts/Interfaces/IInteractionCommandContext.cs
@@ -25,7 +25,7 @@ using JetBrains.Annotations;
 namespace Remora.Discord.Commands.Contexts;
 
 /// <summary>
-/// Represents contextual information about a currently executing text-based command.
+/// Represents contextual information about a currently executing interaction-based command.
 /// </summary>
 [PublicAPI]
 public interface IInteractionCommandContext : IInteractionContext, ICommandContext


### PR DESCRIPTION
Fixes the minor mistake in the summary of `IInteractionCommandContext` and `InteractionCommandContext`
that was mentioned by @jcotton42 in Discord.