### PR TITLE
DocFX: Multiple version support

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.60.0-preview.2",
+      "version": "2.60.0",
       "commands": [
         "docfx"
       ]

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -70,17 +70,19 @@ jobs:
       KEEP_TAG_VERSIONS: 5
 
     steps:
-      - name: Checkout current gh-pages
+      - name: Checkout triggering branch 
+        uses: actions/checkout@v3
+        with:
+          path: base
+
+      - name: Checkout gh-pages
         uses: actions/checkout@v3
         with:
           ref: gh-pages
           path: site
 
-      - name: Clear version
-        working-directory: site
-        run: |
-          rm -rf ${GITHUB_REF_NAME}
-          echo "Cleared ${GITHUB_REF_NAME}"
+      - name: Prepare
+        run: bash base/docfx/scripts/prepare.sh
 
       - name: Download documentation artifacts
         uses: actions/download-artifact@v3
@@ -88,40 +90,8 @@ jobs:
           name: docfx-site
           path: site/${{ github.ref_name }}
 
-      - name: Manage versions
-        shell: bash
-        working-directory: site
-        run: |
-          # Read versions
-          readarray -d '' versions < <( \
-              find . -maxdepth 1 -type d -regextype posix-extended -regex '\./[0-9]{4}\.[0-9]{1,}' -printf '%f\0' \
-            | sort -z -r \
-          )
-
-          # Check if we have to remove old versions
-          if [[ ${#versions[@]} -gt ${KEEP_TAG_VERSIONS} ]]; then
-              echo "::group::Removing old versions"
-              for (( i=${KEEP_TAG_VERSIONS}; i<${#versions[@]}; i++ )); do
-                  echo "${versions[$i]}"
-                  rm -rf ${versions[$i]}
-              done
-              echo "::endgroup::"
-          fi
-
-          # Generate versions.json
-          echo "[" > versions.json
-          echo "  \"main\"" >> versions.json
-          VERSION_COUNT=$((${#versions[@]} > ${KEEP_TAG_VERSIONS} ? ${KEEP_TAG_VERSIONS} : ${#versions[@]}))
-          for (( i=0; i<${VERSION_COUNT}; i++ )); do
-              echo " ,\"${versions[$i]}\"" >> versions.json
-          done
-          echo "]" >> versions.json
-
-          echo "Generated versions.json"
-
-          # Update index.html
-          sed -i -E "s/url=.*\"/url=.\/${versions[0]}\"/" index.html
-          echo "Updated index.html"
+      - name: Build
+        run: bash base/docfx/scripts/build.sh
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,8 +8,10 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [ main ]
+    tags: [ '*' ]
+  pull_request:
 
 jobs:
   build:
@@ -17,6 +19,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: ${{ github.event_name == 'push' }}
+
     - uses: actions/setup-dotnet@v2
       with:
         dotnet-version: |
@@ -34,6 +39,7 @@ jobs:
     - name: Package
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       run: dotnet pack -c Release --no-restore --no-build --version-suffix "github$GITHUB_RUN_ID"
+
     - uses: actions/upload-artifact@v3
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       with:
@@ -41,27 +47,81 @@ jobs:
         path: nuget/*
 
     - name: Build Docs
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: dotnet tool restore && cd ./docfx && dotnet docfx docfx_project/docfx.json
+      if: github.event_name == 'push'
+      run: |
+        dotnet tool restore
+        cd ./docfx
+        sed -i -E "s/%APP_VERSION%/${GITHUB_REF_NAME}/" docfx_project/docfx.json
+        dotnet docfx docfx_project/docfx.json
+
     - uses: actions/upload-artifact@v3
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: github.event_name == 'push'
       with:
         name: docfx-site
         path: docfx/docfx_project/_site/
 
   publish_docs:
-    # TODO: Publish two copies of the docs - one for tagged releases, and one for the latest commit
     name: Publish Documentation
     needs: build
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
+    env:
+      KEEP_TAG_VERSIONS: 5
+
     steps:
+      - name: Checkout current gh-pages
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: site
+
+      - name: Clear version
+        working-directory: site
+        run: |
+          rm -rf ${GITHUB_REF_NAME}
+          echo "Cleared ${GITHUB_REF_NAME}"
+
       - name: Download documentation artifacts
         uses: actions/download-artifact@v3
         with:
           name: docfx-site
-          path: site
+          path: site/${{ github.ref_name }}
+
+      - name: Manage versions
+        shell: bash
+        working-directory: site
+        run: |
+          # Read versions
+          readarray -d '' versions < <( \
+              find . -maxdepth 1 -type d -regextype posix-extended -regex '\./[0-9]{4}\.[0-9]{1,}' -printf '%f\0' \
+            | sort -z -r \
+          )
+
+          # Check if we have to remove old versions
+          if [[ ${#versions[@]} -gt ${KEEP_TAG_VERSIONS} ]]; then
+              echo "::group::Removing old versions"
+              for (( i=${KEEP_TAG_VERSIONS}; i<${#versions[@]}; i++ )); do
+                  echo "${versions[$i]}"
+                  rm -rf ${versions[$i]}
+              done
+              echo "::endgroup::"
+          fi
+
+          # Generate versions.json
+          echo "[" > versions.json
+          echo "  \"main\"" >> versions.json
+          VERSION_COUNT=$((${#versions[@]} > ${KEEP_TAG_VERSIONS} ? ${KEEP_TAG_VERSIONS} : ${#versions[@]}))
+          for (( i=0; i<${VERSION_COUNT}; i++ )); do
+              echo " ,\"${versions[$i]}\"" >> versions.json
+          done
+          echo "]" >> versions.json
+
+          echo "Generated versions.json"
+
+          # Update index.html
+          sed -i -E "s/url=.*\"/url=.\/${versions[0]}\"/" index.html
+          echo "Updated index.html"
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/Backend/Remora.Discord.API/API/Gateway/Commands/RequestGuildMembers.cs
+++ b/Backend/Remora.Discord.API/API/Gateway/Commands/RequestGuildMembers.cs
@@ -34,7 +34,7 @@ namespace Remora.Discord.API.Gateway.Commands;
 /// </summary>
 /// <remarks>
 /// This command has some special requirements related to the presence or absence of certain members in the data
-/// payload. Please read <see cref="!:https://discord.com/developers/docs/topics/gateway#request-guild-members"/> for
+/// payload. Please read <see href="https://discord.com/developers/docs/topics/gateway#request-guild-members"/> for
 /// more information before use, as misuse may cause Discord to terminate the gateway connection.
 /// </remarks>
 [PublicAPI]

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/InteractionAutocompleteCallbackData.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/InteractionAutocompleteCallbackData.cs
@@ -28,7 +28,7 @@ using Remora.Discord.API.Abstractions.Objects;
 
 namespace Remora.Discord.API.Objects;
 
-/// <inheritdoc cref="InteractionAutocompleteCallbackData" />
+/// <inheritdoc cref="IInteractionAutocompleteCallbackData" />
 [PublicAPI]
 public record InteractionAutocompleteCallbackData
 (

--- a/docfx/docfx_project/docfx.json
+++ b/docfx/docfx_project/docfx.json
@@ -66,8 +66,11 @@
     "cleanupCacheHistory": false,
     "disableGitFeatures": false,
     "globalMetadata": {
+      "_appName": "Remora.Discord",
+      "_appTitle": "Remora.Discord",
       "_appLogoPath": "images/1f988.svg",
-      "_appFaviconPath": "images/1f988.svg"
+      "_appFaviconPath": "images/1f988.svg",
+      "_appVersion": "%APP_VERSION%"
     }
   }
 }

--- a/docfx/docfx_project/templates/custom_template/partials/head.tmpl.partial
+++ b/docfx/docfx_project/templates/custom_template/partials/head.tmpl.partial
@@ -16,6 +16,10 @@
   <link rel="stylesheet" href="{{_rel}}styles/main.css">
   <meta property="docfx:navrel" content="{{_navRel}}">
   <meta property="docfx:tocrel" content="{{_tocRel}}">
+  {{#_appVersion}}
+  <meta property="docfx:version" content="{{_appVersion}}">
+  <meta property="docfx:versionsrel" content="{{_rel}}../versions.json">
+  {{/_appVersion}}
   {{#_noindex}}<meta name="searchOption" content="noindex">{{/_noindex}}
   {{#_enableSearch}}<meta property="docfx:rel" content="{{_rel}}">{{/_enableSearch}}
   {{#_enableNewTab}}<meta property="docfx:newtab" content="true">{{/_enableNewTab}}

--- a/docfx/docfx_project/templates/custom_template/partials/navbar.tmpl.partial
+++ b/docfx/docfx_project/templates/custom_template/partials/navbar.tmpl.partial
@@ -1,0 +1,25 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+<div>
+  <div class="mobile-hide">
+    {{>partials/logo}}
+  </div>
+
+  {{#_appVersion}}
+    <div id="versionbar"></div>
+    <div class="sidebar-item-separator"></div>
+  {{/_appVersion}}
+
+  {{#_enableSearch}}
+      <div class="sidesearch">
+          <form id="search" role="search" class="search">
+              <svg width="20" height="20" class="search-icon" viewBox="0 0 20 20"><path d="M14.386 14.386l4.0877 4.0877-4.0877-4.0877c-2.9418 2.9419-7.7115 2.9419-10.6533 0-2.9419-2.9418-2.9419-7.7115 0-10.6533 2.9418-2.9419 7.7115-2.9419 10.6533 0 2.9419 2.9418 2.9419 7.7115 0 10.6533z" stroke="currentColor" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+              <input type="text" id="search-query" placeholder="{{__global.search}}" autocomplete="off">
+          </form>
+      </div>
+  {{/_enableSearch}}
+
+  <div id="navbar">
+  </div>
+</div>
+

--- a/docfx/docfx_project/templates/custom_template/styles/main.css
+++ b/docfx/docfx_project/templates/custom_template/styles/main.css
@@ -232,3 +232,24 @@ article li > ul
     font-style: normal;
     font-weight: normal;
 }
+
+/* Version Bar */
+#versionbar .nav > li.active > .expand-stub::before,
+#versionbar .nav > li.in > .expand-stub::before,
+#versionbar .nav > li.in.active > .expand-stub::before,
+#versionbar .nav > li.filtered > .expand-stub::before {
+    transform: none;
+}
+
+#versionbar .nav > li > .expand-stub::before,
+#versionbar .nav > li.active > .expand-stub::before {
+    content: " ";
+    position: absolute;
+    transform: rotate(-90deg);
+    width: 10px;
+    height: 10px;
+    top: 5px;
+    left: 5px;
+    background-repeat: no-repeat;
+    background: url(down-arrow.svg);
+}

--- a/docfx/docfx_project/templates/custom_template/styles/main.js
+++ b/docfx/docfx_project/templates/custom_template/styles/main.js
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+function toggleMenu() {
+               
+    var x = document.getElementById("sidebar");
+    var b = document.getElementById("blackout");
+
+    if (x.style.left === "0px") 
+    {
+        x.style.left = "-350px";
+        b.classList.remove("showThat");
+        b.classList.add("hideThat");
+    } 
+    else 
+    {
+        x.style.left = "0px";
+        b.classList.remove("hideThat");
+        b.classList.add("showThat");
+    }
+}
+
+(function () {
+    anchors.options = {
+      placement: 'right',
+      visible: 'hover'
+    };
+    anchors.removeAll();
+    anchors.add('article h2:not(.no-anchor), article h3:not(.no-anchor), article h4:not(.no-anchor)');
+
+    function renderVersionBar() {
+        let versionsPath = $("meta[property='docfx\\:versionsrel']").attr("content");
+        if (!versionsPath) return;
+        versionsPath = versionsPath.replace(/\\/g, '/');
+        
+        const versionBasePath = versionsPath.substring(0, versionsPath.lastIndexOf("/"));
+        const currentVersion = $("meta[property='docfx\\:version']").attr("content");
+        
+        $.ajax({
+            url: versionsPath,
+            dataType: "json",
+            cache: false,
+            success: function (versions) {
+                const versionBar = $("#versionbar");
+                versionBar.empty();
+
+                const versionBarElement = $('<ul class="nav level2"></ul>');
+                versionBarElement.append(function() {
+                    const list = $(`<ul class="nav level3" />`);
+                    
+                    for (var version of versions.filter(x => x !== currentVersion)) {
+                        list.append(`<li><a class="sidebar-item" href="${versionBasePath}/${version}">${version}</a></li>`);
+                    }
+
+                    return $(`<li>
+                                <span class="expand-stub"></span>
+                                <a class="active sidebar-item">Version: <b>${currentVersion}</b></a>
+                            </li>`)
+                        .append(list);
+                });
+
+                versionBar.append(versionBarElement);
+
+                $("#versionbar .nav > li > .expand-stub").click(function (e) {
+                    $(e.target).parent().toggleClass("in");
+                });
+                $("#versionbar .nav > li > .expand-stub + a:not([href])").click(function (e) {
+                    $(e.target).parent().toggleClass("in");
+                });
+            }
+        });
+    }
+
+    renderVersionBar();
+})();

--- a/docfx/scripts/_common.sh
+++ b/docfx/scripts/_common.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DOCFX_DIR=${GITHUB_WORKSPACE}/base/docfx
+SITE_DIR=${GITHUB_WORKSPACE}/site

--- a/docfx/scripts/build.sh
+++ b/docfx/scripts/build.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+source $(dirname "$0")/_common.sh
+cd ${SITE_DIR}
+
+TEMPLATE_DIR=${DOCFX_DIR}/templates
+
+build_versions_json() {
+    # Read versions
+    readarray -d '' versions < <( \
+        find . -maxdepth 1 -type d -regextype posix-extended -regex '\./[0-9]{4}\.[0-9]{1,}' -printf '%f\0' \
+      | sort -z -r \
+    )
+
+    # Check if we have to remove old versions
+    if [[ ${#versions[@]} -gt ${KEEP_TAG_VERSIONS} ]]; then
+        echo "::group::Removing old versions"
+        local version_count=${#versions[@]}
+        for (( i=${KEEP_TAG_VERSIONS}; i<${version_count}; i++ )); do
+            echo "${versions[$i]}"
+            # rm -rf ${versions[$i]}
+            unset "versions[$i]"
+        done
+        echo "::endgroup::"
+    fi
+
+
+    # Generate versions.json
+    echo "[" > versions.json
+    echo "  \"main\"" >> versions.json
+    for (( i=0; i<${#versions[@]}; i++ )); do
+        echo " ,\"${versions[$i]}\"" >> versions.json
+    done
+    echo "]" >> versions.json
+
+    versions+=( "main" )
+
+    echo "Generated versions.json"
+}
+
+copy_template() {
+    local file=$1
+    local src_file=${TEMPLATE_DIR}/${file}
+    local dest_file=${SITE_DIR}/${file}
+
+    mkdir -p $(dirname "${dest_file}")
+
+    cat ${src_file} \
+        | sed -E "s/%LATEST_VERSION%/${versions[0]}/" \
+        > ${dest_file}
+
+    echo " - ${file}"
+}
+
+build_versions_json
+
+echo "::group::Copy templates"
+find ${TEMPLATE_DIR} -type f -printf '%P\n' | while read f; do
+    copy_template "$f"
+done
+echo "::endgroup::"

--- a/docfx/scripts/prepare.sh
+++ b/docfx/scripts/prepare.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source $(dirname "$0")/_common.sh
+cd ${SITE_DIR}
+
+# Clean site
+echo "::group::Clean site"
+find . -mindepth 1 -maxdepth 1 -type f -exec rm -v {} +
+find . -mindepth 1 -maxdepth 1 -type d -regextype posix-extended -not -regex '\./(\.git|main|[0-9]{4}\.[0-9]{1,})' -exec rm -rv {} \;
+echo "::endgroup::"
+
+# Delete current built branch/tag directory
+rm -rf ${GITHUB_REF_NAME}
+echo "Removed ${GITHUB_REF_NAME}"

--- a/docfx/templates/index.html
+++ b/docfx/templates/index.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=./%LATEST_VERSION%" />
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
This PR customizes the build workflow to publish multiple versions of
the documentation.

It is setup to always keep the `main` branch and the latest 5 tags (variable `KEEP_TAG_VERSIONS`).
The `index.html` is edited on every build to redirect to the latest tag.

## Remark
Before merging into `main` branch the `gh-pages` branch must be cleaned up, to consist only of following files:

#### - `.nojekyll`

#### - `index.html`
```html
<html>
  <head>
    <meta http-equiv="refresh" content="0; url=./main" />
  </head>
  <body></body>
</html>
```