### PR TITLE
TextInputComponent value must not be empty

### DIFF
--- a/Samples/Interactivity/Commands/InteractiveCommands.cs
+++ b/Samples/Interactivity/Commands/InteractiveCommands.cs
@@ -233,7 +233,7 @@ public class InteractiveCommands : CommandGroup
                                     1,
                                     32,
                                     true,
-                                    string.Empty,
+                                    default,
                                     "Short Text here"
                                 )
                             }


### PR DESCRIPTION
Discord does not allow an zero length string as value for TextInputComponent.