### PR TITLE
Implement a service that makes permission computation less of a hassle

### DIFF
--- a/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Extensions/Extensions/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Remora.Commands.Extensions;
 using Remora.Commands.Groups;
 using Remora.Discord.Extensions.Attributes;
+using Remora.Discord.Extensions.Services;
 using Remora.Discord.Gateway.Extensions;
 using Remora.Discord.Gateway.Responders;
 using Remora.Discord.Interactivity;
@@ -40,6 +41,17 @@ namespace Remora.Discord.Extensions.Extensions;
 [PublicAPI]
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds services provided by Remora.Discord.Extensions.
+    /// </summary>
+    /// <param name="serviceCollection">The service collection.</param>
+    /// <returns>The service collection, with the services added.</returns>
+    public static IServiceCollection AddExtensions(this IServiceCollection serviceCollection)
+    {
+        serviceCollection.AddScoped<IPermissionComputationService, PermissionComputationService>();
+        return serviceCollection;
+    }
+
     /// <summary>
     /// Automatically registers every command group in the given assembly.
     /// </summary>

--- a/Remora.Discord.Extensions/Remora.Discord.Extensions.csproj
+++ b/Remora.Discord.Extensions/Remora.Discord.Extensions.csproj
@@ -15,4 +15,10 @@
         <ProjectReference Include="..\Remora.Discord.Interactivity\Remora.Discord.Interactivity.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Compile Update="Services\IPermissionComputationService.cs">
+        <DependentUpon>PermissionComputationService.cs</DependentUpon>
+      </Compile>
+    </ItemGroup>
+
 </Project>

--- a/Remora.Discord.Extensions/Services/IPermissionComputationService.cs
+++ b/Remora.Discord.Extensions/Services/IPermissionComputationService.cs
@@ -1,0 +1,126 @@
+//
+//  IPermissionComputationService.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Commands.Contexts;
+using Remora.Rest.Core;
+using Remora.Results;
+
+namespace Remora.Discord.Extensions.Services;
+
+/// <summary>
+/// Computes permission sets based on available data.
+/// </summary>
+[PublicAPI]
+public interface IPermissionComputationService
+{
+    /// <summary>
+    /// Computes the effective permissions for the user with the given ID.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="channelID"/> controls whether permission overwrite in any particular channel are taken into
+    /// account. If it is omitted, the computed permissions are valid anywhere in the server where a permission
+    /// overwrite does not otherwise modify the permissions.
+    ///
+    /// If you want to compute effective permissions for some kind of user action, it's likely that you want to set this
+    /// parameter to an appropriate value.
+    /// </remarks>
+    /// <param name="userID">The ID of the user.</param>
+    /// <param name="guildID">The ID of the guild the user is in.</param>
+    /// <param name="channelID">The ID of the channel the user is in.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>The computed permissions.</returns>
+    Task<Result<IDiscordPermissionSet>> ComputeMemberPermissions
+    (
+        Snowflake userID,
+        Snowflake guildID,
+        Snowflake? channelID = null,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Computes the effective permissions for the user with the given ID in the context of the current operation.
+    /// </summary>
+    /// <remarks>
+    /// This method uses the guild and channel ID from an available <see cref="IOperationContext"/>.
+    /// </remarks>
+    /// <param name="userID">The ID of the user.</param>
+    /// <param name="inChannel">Whether the computation should use the channel ID from the context.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <exception cref="InvalidOperationError">
+    /// Thrown if no context is available or it does not have the required information.
+    /// </exception>
+    /// <returns>The computed permissions.</returns>
+    Task<Result<IDiscordPermissionSet>> ComputeContextualMemberPermissions
+    (
+        Snowflake userID,
+        bool inChannel = true,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Computes the effective permissions for the role with the given ID.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="channelID"/> controls whether permission overwrite in any particular channel are taken into
+    /// account. If it is omitted, the computed permissions are valid anywhere in the server where a permission
+    /// overwrite does not otherwise modify the permissions.
+    ///
+    /// If you want to compute effective permissions for some kind of user action, it's likely that you want to set this
+    /// parameter to an appropriate value.
+    /// </remarks>
+    /// <param name="roleID">The ID of the role.</param>
+    /// <param name="guildID">The ID of the guild the user is in.</param>
+    /// <param name="channelID">The ID of the channel the user is in.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>The computed permissions.</returns>
+    Task<Result<IDiscordPermissionSet>> ComputeRolePermissions
+    (
+        Snowflake roleID,
+        Snowflake guildID,
+        Snowflake? channelID = null,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Computes the effective permissions for the role with the given ID in the context of the current operation.
+    /// </summary>
+    /// <remarks>
+    /// This method uses the guild and channel ID from an available <see cref="IOperationContext"/>.
+    /// </remarks>
+    /// <param name="roleID">The ID of the role.</param>
+    /// <param name="inChannel">Whether the computation should use the channel ID from the context.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <exception cref="InvalidOperationError">
+    /// Thrown if no context is available or it does not have the required information.
+    /// </exception>
+    /// <returns>The computed permissions.</returns>
+    Task<Result<IDiscordPermissionSet>> ComputeContextualRolePermissions
+    (
+        Snowflake roleID,
+        bool inChannel = true,
+        CancellationToken ct = default
+    );
+}

--- a/Remora.Discord.Extensions/Services/PermissionComputationService.cs
+++ b/Remora.Discord.Extensions/Services/PermissionComputationService.cs
@@ -1,0 +1,198 @@
+//
+//  PermissionComputationService.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Abstractions.Rest;
+using Remora.Discord.API.Objects;
+using Remora.Discord.Commands.Extensions;
+using Remora.Discord.Commands.Services;
+using Remora.Rest.Core;
+using Remora.Results;
+
+namespace Remora.Discord.Extensions.Services;
+
+/// <inheritdoc />
+public class PermissionComputationService : IPermissionComputationService
+{
+    private readonly ContextInjectionService _contextInjection;
+    private readonly IDiscordRestGuildAPI _guildAPI;
+    private readonly IDiscordRestChannelAPI _channelAPI;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PermissionComputationService"/> class.
+    /// </summary>
+    /// <param name="contextInjection">The context injection service.</param>
+    /// <param name="guildAPI">The guild API.</param>
+    /// <param name="channelAPI">The channel API.</param>
+    public PermissionComputationService
+    (
+        ContextInjectionService contextInjection,
+        IDiscordRestGuildAPI guildAPI,
+        IDiscordRestChannelAPI channelAPI
+    )
+    {
+        _contextInjection = contextInjection;
+        _guildAPI = guildAPI;
+        _channelAPI = channelAPI;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Result<IDiscordPermissionSet>> ComputeMemberPermissions
+    (
+        Snowflake userID,
+        Snowflake guildID,
+        Snowflake? channelID = null,
+        CancellationToken ct = default
+    )
+    {
+        var getMember = await _guildAPI.GetGuildMemberAsync(guildID, userID, ct);
+        if (!getMember.IsDefined(out var member))
+        {
+            return Result<IDiscordPermissionSet>.FromError(getMember);
+        }
+
+        var getGuildRoles = await _guildAPI.GetGuildRolesAsync(guildID, ct);
+        if (!getGuildRoles.IsDefined(out var guildRoles))
+        {
+            return Result<IDiscordPermissionSet>.FromError(getGuildRoles);
+        }
+
+        var everyoneRole = guildRoles.First(r => r.ID == guildID);
+        var memberRoles = guildRoles.Where(r => member.Roles.Contains(r.ID)).ToList();
+        IReadOnlyList<IPermissionOverwrite>? overwrites = null;
+
+        // ReSharper disable once InvertIf
+        if (channelID is not null)
+        {
+            var getChannel = await _channelAPI.GetChannelAsync(channelID.Value, ct);
+            if (!getChannel.IsDefined(out var channel))
+            {
+                return Result<IDiscordPermissionSet>.FromError(getChannel);
+            }
+
+            overwrites = channel.PermissionOverwrites.OrDefault();
+        }
+
+        return Result<IDiscordPermissionSet>.FromSuccess
+        (
+            DiscordPermissionSet.ComputePermissions(userID, everyoneRole, memberRoles, overwrites)
+        );
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IDiscordPermissionSet>> ComputeContextualMemberPermissions
+    (
+        Snowflake userID,
+        bool inChannel = true,
+        CancellationToken ct = default
+    )
+    {
+        if (_contextInjection.Context is null)
+        {
+            throw new InvalidOperationException("Contextual permission computation requires an available context.");
+        }
+
+        var context = _contextInjection.Context;
+
+        if (!context.TryGetGuildID(out var guildID))
+        {
+            throw new InvalidOperationException("Contextual permission computation requires an available guild ID.");
+        }
+
+        if (!context.TryGetChannelID(out var channelID) && inChannel)
+        {
+            throw new InvalidOperationException("Contextual permission computation requires an available channel ID.");
+        }
+
+        return ComputeMemberPermissions(userID, guildID.Value, channelID, ct);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Result<IDiscordPermissionSet>> ComputeRolePermissions
+    (
+        Snowflake roleID,
+        Snowflake guildID,
+        Snowflake? channelID = null,
+        CancellationToken ct = default
+    )
+    {
+        var getGuildRoles = await _guildAPI.GetGuildRolesAsync(guildID, ct);
+        if (!getGuildRoles.IsDefined(out var guildRoles))
+        {
+            return Result<IDiscordPermissionSet>.FromError(getGuildRoles);
+        }
+
+        var everyoneRole = guildRoles.First(r => r.ID == guildID);
+        var role = guildRoles.Single(r => r.ID == roleID);
+        IReadOnlyList<IPermissionOverwrite>? overwrites = null;
+
+        // ReSharper disable once InvertIf
+        if (channelID is not null)
+        {
+            var getChannel = await _channelAPI.GetChannelAsync(channelID.Value, ct);
+            if (!getChannel.IsDefined(out var channel))
+            {
+                return Result<IDiscordPermissionSet>.FromError(getChannel);
+            }
+
+            overwrites = channel.PermissionOverwrites.OrDefault();
+        }
+
+        return Result<IDiscordPermissionSet>.FromSuccess
+        (
+            DiscordPermissionSet.ComputePermissions(role, everyoneRole, overwrites)
+        );
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IDiscordPermissionSet>> ComputeContextualRolePermissions
+    (
+        Snowflake roleID,
+        bool inChannel = true,
+        CancellationToken ct = default
+    )
+    {
+        if (_contextInjection.Context is null)
+        {
+            throw new InvalidOperationException("Contextual permission computation requires an available context.");
+        }
+
+        var context = _contextInjection.Context;
+
+        if (!context.TryGetGuildID(out var guildID))
+        {
+            throw new InvalidOperationException("Contextual permission computation requires an available guild ID.");
+        }
+
+        if (!context.TryGetChannelID(out var channelID) && inChannel)
+        {
+            throw new InvalidOperationException("Contextual permission computation requires an available channel ID.");
+        }
+
+        return ComputeRolePermissions(roleID, guildID.Value, channelID, ct);
+    }
+}


### PR DESCRIPTION
This PR adds a new service to Remora.Discord.Extensions that should make member permission calculation more palatable. In particular, it abstracts away the required API calls to gather the neccesary information and exposes a set of methods that can be used when an operation context is available instead of having to pass in contextual values.

Opinions and suggestions are welcome.