### PR TITLE
Implement token-scoped cache keys

### DIFF
--- a/Backend/Remora.Discord.Caching/Services/CacheService.cs
+++ b/Backend/Remora.Discord.Caching/Services/CacheService.cs
@@ -45,7 +45,11 @@ public class CacheService
     /// </summary>
     /// <param name="cacheProvider">The cache provider.</param>
     /// <param name="cacheSettings">The cache settings.</param>
-    public CacheService(ICacheProvider cacheProvider, ImmutableCacheSettings cacheSettings)
+    public CacheService
+    (
+        ICacheProvider cacheProvider,
+        ImmutableCacheSettings cacheSettings
+    )
     {
         _cacheProvider = cacheProvider;
         _cacheSettings = cacheSettings;


### PR DESCRIPTION
This PR implements simple scoping for the cache library in order to keep data belonging to different tokens separate.

In its current state, it is not a complete implementation since tokens provided via customizations onto single REST requests will not be picked up, and that mechanism may need some more in-depth changes. Consider this a design suggestion out for comments.

Fixes #257.