### PR TITLE
Shortens anchor links in documentation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "docfx/docfx_project/templates/discordfx"]
 	path = docfx/docfx_project/templates/discordfx
 	url = https://github.com/jbltx/DiscordFX.git
+[submodule "docfx/docfx_project/templates/shortanchor"]
+	path = docfx/docfx_project/templates/shortanchor
+	url = https://github.com/MazeXP/DocFX.ShortAnchor.git

--- a/docfx/docfx_project/docfx.json
+++ b/docfx/docfx_project/docfx.json
@@ -58,6 +58,7 @@
     "template": [
       "default",
       "templates/discordfx/discordfx",
+      "templates/shortanchor/templates",
       "templates/custom_template"
     ],
     "postProcessors": [],


### PR DESCRIPTION
This PR shortens the anchors to members of a type in the documentation.

### Anchor generation
1. Strip Type FullName from UID
2. Append index based on occurence of member name per type

### Before:
```
.../api/Remora.Discord.Rest.API.DiscordRestWebhookAPI.html#Remora_Discord_Rest_API_DiscordRestWebhookAPI_EditWebhookMessageAsync_Remora_Rest_Core_Snowflake_System_String_Remora_Rest_Core_Snowflake_Remora_Rest_Core_Optional_System_String__Remora_Rest_Core_Optional_System_Collections_Generic_IReadOnlyList_Remora_Discord_API_Abstractions_Objects_IEmbed___Remora_Rest_Core_Optional_Remora_Discord_API_Abstractions_Objects_IAllowedMentions__Remora_Rest_Core_Optional_System_Collections_Generic_IReadOnlyList_Remora_Discord_API_Abstractions_Objects_IMessageComponent___Remora_Rest_Core_Optional_System_Collections_Generic_IReadOnlyList_OneOf_OneOf_Remora_Discord_API_Abstractions_Rest_FileData_Remora_Discord_API_Abstractions_Objects_IPartialAttachment____Remora_Rest_Core_Optional_Remora_Rest_Core_Snowflake__System_Threading_CancellationToken_
```

### After
```
.../api/Remora.Discord.Rest.API.DiscordRestWebhookAPI.html#EditWebhookMessageAsync_1
```