### PR TITLE
Optimize receving payloads¹

### DIFF
--- a/Backend/Remora.Discord.Gateway/Remora.Discord.Gateway.csproj
+++ b/Backend/Remora.Discord.Gateway/Remora.Discord.Gateway.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="CommunityToolkit.HighPerformance" />
       <PackageReference Include="Remora.Extensions.Options.Immutable" />
       <PackageReference Include="System.Threading.Channels" />
     </ItemGroup>

--- a/Backend/Remora.Discord.Gateway/Transport/WebSocketPayloadTransportService.cs
+++ b/Backend/Remora.Discord.Gateway/Transport/WebSocketPayloadTransportService.cs
@@ -227,8 +227,6 @@ public class WebSocketPayloadTransportService : IPayloadTransportService, IAsync
             return new InvalidOperationError("The socket was not open.");
         }
 
-        await using var memoryStream = new MemoryStream();
-
         using var bufferWriter = new ArrayPoolBufferWriter<byte>(); // Backed by the ArrayPool; the only allocation is the class itself
 
         var buffer = bufferWriter.GetMemory(4096);

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
+    <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.1.0" />
     <PackageVersion Include="FuzzySharp" Version="2.0.2" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />


### PR DESCRIPTION
¹This PR only optimizes `WebSocketPayloadTransportService`'s `ReceiveAsync` method.

This PR is one of many that will tackle various issues mentioned in #254.

This one in particular relates to the performance (speed, allocations) concerns raised by the current implementation of receiving a payload (as implemented by the aforementioned class).

Notable changes are: 
- Using `CommunityToolKit.HighPerformance`
- Switching `WebSocketReceiveResult` to its struct-based alternative
- Using reusable² buffers
- Using `JsonSerializer.Deserialize<T>` instead of its async alternative

## Considerations and justifications

It should be considered that as a critical part of the library, it's important that this code is battle-tested, and not just validated by unit-tests. In theory, the logic of the receive flow has not changed, but there's always the possibility for bugs and edge-cases that may be directly or indirectly found becuase of this PR; any bugs reported in regards to receiving gateway payloads should probably reference this PR for ease of tracking.

²The implementation of `ArrayPoolBufferWriter<T>` is backed by `ArrayPool<T>.Shared` by default

As for *why* these changes were made:

`CommunityToolKit.HighPerformance` is, as it says on the tin, a high-performance set of tools and APIs (such as `ArrayPoolBufferWriter<T>`) which could have even futher utlization within Remora after some careful consideration and triaging of potential optimizations (such as those commented upon in #254). (SendAsync was not changed as incoming payloads outnumber outgoing by upward of several orders of magnitude for larger bots).

The change to `ValueWebSocketReceiveResult` is twofold; `ArrayPoolBufferWriter<T>` exposes `Memory<T>` and `Span<T>`, the former of which is accepted as an overload to `ClientWebSocket#ReceiveAsync`, which is returns a struct result instead. This struct only contains two fields, so is much smaller, and never touches the heap. This optimization, if it can be called such, comes for free as a side-effect of other changes.

`JsonSerializer.DeserializeAsync<T>` was changed to its synchronous alternative because:

- JSON Deserialization is synchronous
- The Async overload only reads from the stream asynchronously

```cs
while (true)
{
    bufferState = await bufferState.ReadFromStreamAsync(utf8Json, cancellationToken).ConfigureAwait(false);
    TValue? value = ContinueDeserialize<TValue>(ref bufferState, ref jsonReaderState, ref readStack, jsonTypeInfo);

    if (bufferState.IsFinalBlock)
    {
        return value;
    }
}
```

The latter is especially important to consider, given *where* the data is coming from.

Becuase the only asynchronous part of the deserialization part is reading from the stream, this is rather bad becuase the stream it's reading from is a `MemoryStream`, which means all the data it's reading is already sitting in memory, not on the wire/on disk. Becuase of this, the overhead of async actually causes deserialization to be *slower* than if the synchronous version was used.

