### PR TITLE
refactor!: Extract dispatch to interface

### DIFF
--- a/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
+++ b/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
@@ -65,7 +65,7 @@ public class DiscordGatewayClient : IDisposable
     private readonly ITokenStore _tokenStore;
     private readonly Random _random;
 
-    private readonly ResponderDispatchService _responderDispatch;
+    private readonly IResponderDispatchService _responderDispatch;
 
     /// <summary>
     /// Holds payloads that have been submitted by the application, but have not yet been sent to the gateway.
@@ -134,7 +134,7 @@ public class DiscordGatewayClient : IDisposable
         Random random,
         ILogger<DiscordGatewayClient> log,
         IServiceProvider services,
-        ResponderDispatchService responderDispatch
+        IResponderDispatchService responderDispatch
     )
     {
         _gatewayAPI = gatewayAPI;

--- a/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
@@ -66,11 +66,12 @@ public static class ServiceCollectionExtensions
             );
 
         serviceCollection.TryAddSingleton<Random>();
-        serviceCollection.TryAddSingleton<ResponderDispatchService>();
+        serviceCollection.TryAddSingleton<IResponderDispatchService, ResponderDispatchService>();
         serviceCollection.TryAddSingleton<IResponderTypeRepository>
         (
             s => s.GetRequiredService<IOptions<ResponderService>>().Value
         );
+
         serviceCollection.TryAddSingleton<DiscordGatewayClient>();
 
         serviceCollection.TryAddTransient<ClientWebSocket>();

--- a/Backend/Remora.Discord.Gateway/ResponderDispatchOptions.cs
+++ b/Backend/Remora.Discord.Gateway/ResponderDispatchOptions.cs
@@ -26,7 +26,7 @@ using Remora.Discord.Gateway.Services;
 namespace Remora.Discord.Gateway;
 
 /// <summary>
-///  Represents options related to <see cref="ResponderDispatchService"/>.
+///  Represents options related to <see cref="IResponderDispatchService"/>.
 /// </summary>
 /// <param name="MaxItems">How many items can be queued for dispatch at any given time.</param>
 [PublicAPI]

--- a/Backend/Remora.Discord.Gateway/Services/IResponderDispatchService.cs
+++ b/Backend/Remora.Discord.Gateway/Services/IResponderDispatchService.cs
@@ -1,0 +1,47 @@
+//
+//  IResponderDispatchService.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Threading;
+using System.Threading.Tasks;
+using Remora.Discord.API.Abstractions.Gateway;
+using Remora.Results;
+
+namespace Remora.Discord.Gateway.Services;
+
+/// <summary>
+/// Manages dispatch and processing of gateway payloads.
+/// </summary>
+public interface IResponderDispatchService
+{
+    /// <summary>
+    /// Dispatches the given payload to interested responders. If the service is stopped with pending dispatches, the
+    /// pending payloads will be dropped. Any payloads that have been dispatched (that is, a call to this method has
+    /// returned a successful result) will be allowed to run to completion.
+    /// </summary>
+    /// <param name="payload">The payload to dispatch.</param>
+    /// <param name="ct">
+    /// The cancellation token for this operation. Note that this is *not* the cancellation token which will be passed
+    /// to any instantiated responders.
+    /// </param>
+    /// <returns>A result which may or may not have succeeded.</returns>
+    Task<Result> DispatchAsync(IPayload payload, CancellationToken ct = default);
+}

--- a/Backend/Remora.Discord.Gateway/Services/ResponderDispatchService.cs
+++ b/Backend/Remora.Discord.Gateway/Services/ResponderDispatchService.cs
@@ -39,11 +39,9 @@ using Remora.Results;
 
 namespace Remora.Discord.Gateway.Services;
 
-/// <summary>
-/// Manages dispatch and processing of gateway payloads.
-/// </summary>
+/// <inheritdoc cref="IResponderDispatchService"/>
 [PublicAPI]
-public class ResponderDispatchService : IAsyncDisposable
+public class ResponderDispatchService : IAsyncDisposable, IResponderDispatchService
 {
     private readonly IServiceProvider _services;
     private readonly ResponderDispatchOptions _options;


### PR DESCRIPTION
This PR does what it says on the tin; this extracts the dispatcher to an interface, allowing for different implementations (such as maybe a mass-transit backed, or even Source-Generated implementation 😉)