### PR TITLE
Fix convert discrepancies between partial and non-partial type

### DIFF
--- a/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
@@ -545,7 +545,8 @@ public static class ServiceCollectionExtensions
         options.AddDataObjectConverter<IPartialChannel, PartialChannel>()
             .WithPropertyName(c => c.IsNsfw, "nsfw")
             .WithPropertyName(c => c.IsManaged, "managed")
-            .WithPropertyConverter(c => c.RateLimitPerUser, new UnitTimeSpanConverter(TimeUnit.Seconds));
+            .WithPropertyConverter(c => c.RateLimitPerUser, new UnitTimeSpanConverter(TimeUnit.Seconds))
+            .WithPropertyConverter(c => c.DefaultThreadRateLimitPerUser, new UnitTimeSpanConverter(TimeUnit.Seconds));
 
         options.AddDataObjectConverter<IChannelMention, ChannelMention>();
         options.AddDataObjectConverter<IAllowedMentions, AllowedMentions>()
@@ -766,7 +767,9 @@ public static class ServiceCollectionExtensions
             .WithPropertyConverter(a => a.Duration, new UnitTimeSpanConverter(TimeUnit.Seconds));
 
         options.AddDataObjectConverter<IPartialAttachment, PartialAttachment>()
-            .WithPropertyName(a => a.IsEphemeral, "ephemeral");
+            .WithPropertyName(a => a.IsEphemeral, "ephemeral")
+            .WithPropertyName(a => a.Duration, "duration_secs")
+            .WithPropertyConverter(a => a.Duration, new UnitTimeSpanConverter(TimeUnit.Seconds));
 
         options.AddDataObjectConverter<IEmbed, Embed>()
             .WithPropertyConverter(e => e.Type, new StringEnumConverter<EmbedType>(new SnakeCaseNamingPolicy()))


### PR DESCRIPTION
In cases when a `PartialChannel` object has a `default_thread_rate_limit_per_user` property provided,
the deserialization would fail as it was trying to convert the TimeSpan using the default
`TimeSpanConverter` (expects string) instead of the `UnitTimeSpanConverter` (expects double/integer).

In addition I found a similiar discrepancy between `IAttachment` and `IPartialAttachment` (`duration_secs`),
so I got them also on par.