### PR TITLE
Change thread_id from Form to Query String param

### DIFF
--- a/Backend/Remora.Discord.Rest/API/Webhooks/DiscordRestWebhookAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Webhooks/DiscordRestWebhookAPI.cs
@@ -317,6 +317,11 @@ public class DiscordRestWebhookAPI : AbstractDiscordRestAPI, IDiscordRestWebhook
                     b.AddQueryParameter("wait", realShouldWait.ToString());
                 }
 
+                if (threadID.TryGet(out var realThreadID))
+                {
+                    b.AddQueryParameter("thread_id", realThreadID.ToString());
+                }
+
                 Optional<IReadOnlyList<IPartialAttachment>> attachmentList = default;
                 if (attachments.TryGet(out var realAttachments))
                 {
@@ -354,7 +359,6 @@ public class DiscordRestWebhookAPI : AbstractDiscordRestAPI, IDiscordRestWebhook
                             json.Write("tts", isTTS, this.JsonOptions);
                             json.Write("embeds", embeds, this.JsonOptions);
                             json.Write("allowed_mentions", allowedMentions, this.JsonOptions);
-                            json.Write("thread_id", threadID, this.JsonOptions);
                             json.Write("components", components, this.JsonOptions);
                             json.Write("attachments", attachmentList, this.JsonOptions);
                             json.Write("flags", flags, this.JsonOptions);

--- a/Tests/Remora.Discord.Rest.Tests/API/Webhooks/DiscordRestWebhookAPITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/Webhooks/DiscordRestWebhookAPITests.cs
@@ -817,6 +817,7 @@ public class DiscordRestWebhookAPITests
                 b => b
                     .Expect(HttpMethod.Post, $"{Constants.BaseURL}webhooks/{webhookId}/{token}")
                     .WithQueryString("wait", shouldWait.ToString())
+                    .WithQueryString("thread_id", threadID.ToString())
                     .WithJson
                     (
                         j => j.IsObject
@@ -827,7 +828,6 @@ public class DiscordRestWebhookAPITests
                                 .WithProperty("avatar_url", p => p.Is(avatarUrl))
                                 .WithProperty("tts", p => p.Is(tts))
                                 .WithProperty("allowed_mentions", p => p.IsObject())
-                                .WithProperty("thread_id", p => p.Is(threadID.ToString()))
                                 .WithProperty("components", p => p.IsArray())
                                 .WithProperty("flags", p => p.Is((int)flags))
                         )


### PR DESCRIPTION
https://discord.com/developers/docs/resources/webhook#execute-webhook has this listed as a query string parameter not a form parameter and therefore posting to an existing forum thread is broken. I think it also updates the test correctly to account for this but not as sure about that