### PR TITLE
feat: Add new permissions

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Permissions/DiscordPermission.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Permissions/DiscordPermission.cs
@@ -275,6 +275,16 @@ public enum DiscordPermission
     SendVoiceMessages = 46,
 
     /// <summary>
+    /// Allows for interaction with Clyde (AI).
+    /// </summary>
+    UseClydeAi = 47,
+
+    /// <summary>
+    /// Allows for setting the status of a voice channel.
+    /// </summary>
+    SetVoiceChannelStatus = 48,
+
+    /// <summary>
     /// Allows for sending polls.
     /// </summary>
     SendPolls = 49,


### PR DESCRIPTION
This commit implements the new permissions (USE_CLYDE_AI, SET_VOICE_CHANNEL_STATUS, and CREATE_GUILD_EXPRESSIONS) as seen in these PRs:

~~https://github.com/discord/discord-api-docs/pull/6354~~ PR was closed
https://github.com/discord/discord-api-docs/pull/6398 PR is open -> Blocker
https://github.com/discord/discord-api-docs/pull/6305 PR was merged