### PR TITLE
Remove global_name from User objects to comply with OpenAPI spec UserPIIResponse and UserResponse objects

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Gateway/Events/Users/IUserUpdate.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Gateway/Events/Users/IUserUpdate.cs
@@ -28,6 +28,7 @@ namespace Remora.Discord.API.Abstractions.Gateway.Events;
 /// <summary>
 /// Represents an update to a user.
 /// </summary>
+/// <inheritdoc cref="IUser" path="/remarks"/>
 [PublicAPI]
 public interface IUserUpdate : IGatewayEvent, IUser
 {

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IPartialUser.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IPartialUser.cs
@@ -29,6 +29,7 @@ namespace Remora.Discord.API.Abstractions.Objects;
 /// <summary>
 /// Represents a partial Discord user.
 /// </summary>
+/// <inheritdoc cref="IUser" path="/remarks"/>
 [PublicAPI]
 public interface IPartialUser
 {
@@ -40,9 +41,6 @@ public interface IPartialUser
 
     /// <inheritdoc cref="IUser.Discriminator" />
     Optional<ushort> Discriminator { get; }
-
-    /// <inheritdoc cref="IUser.GlobalName" />
-    // Optional<string?> GlobalName { get; }
 
     /// <inheritdoc cref="IUser.Avatar" />
     Optional<IImageHash?> Avatar { get; }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IPartialUser.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IPartialUser.cs
@@ -42,7 +42,7 @@ public interface IPartialUser
     Optional<ushort> Discriminator { get; }
 
     /// <inheritdoc cref="IUser.GlobalName" />
-    Optional<string?> GlobalName { get; }
+    // Optional<string?> GlobalName { get; }
 
     /// <inheritdoc cref="IUser.Avatar" />
     Optional<IImageHash?> Avatar { get; }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUser.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUser.cs
@@ -29,6 +29,9 @@ namespace Remora.Discord.API.Abstractions.Objects;
 /// <summary>
 /// Represents a Discord user.
 /// </summary>
+/// <remarks>
+/// global_name intentionally not implemented as this field is not present in Discord's OpenAPI specification, despite being documented.
+/// </remarks>
 [PublicAPI]
 public interface IUser : IPartialUser
 {
@@ -51,15 +54,6 @@ public interface IUser : IPartialUser
     /// </summary>
     /// <remarks>Discord no longer uses discriminators, and migrated users will simply have '0' as their discriminator.</remarks>
     new ushort Discriminator { get; }
-
-    /// <summary>
-    /// Gets the user's display name, if it is set. For bots, this is the application name.
-    /// </summary>
-    /// <remarks>
-    /// Intentionally not implemented as this field is not present in Discord's OpenAPI specification.
-    /// Despite being documented, it is not fully implemented and is not returned by many endpoints.
-    /// </remarks>
-    // new string? GlobalName { get; }
 
     /// <summary>
     /// Gets the user's avatar hash.
@@ -135,9 +129,6 @@ public interface IUser : IPartialUser
 
     /// <inheritdoc/>
     Optional<ushort> IPartialUser.Discriminator => this.Discriminator;
-
-    /// <inheritdoc/>
-    // Optional<string?> IPartialUser.GlobalName => this.GlobalName;
 
     /// <inheritdoc/>
     Optional<IImageHash?> IPartialUser.Avatar => new(this.Avatar);

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUser.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUser.cs
@@ -55,7 +55,11 @@ public interface IUser : IPartialUser
     /// <summary>
     /// Gets the user's display name, if it is set. For bots, this is the application name.
     /// </summary>
-    new string? GlobalName { get; }
+    /// <remarks>
+    /// Intentionally not implemented as this field is not present in Discord's OpenAPI specification.
+    /// Despite being documented, it is not fully implemented and is not returned by many endpoints
+    /// </remarks>
+    // new string? GlobalName { get; }
 
     /// <summary>
     /// Gets the user's avatar hash.
@@ -133,7 +137,7 @@ public interface IUser : IPartialUser
     Optional<ushort> IPartialUser.Discriminator => this.Discriminator;
 
     /// <inheritdoc/>
-    Optional<string?> IPartialUser.GlobalName => this.GlobalName;
+    // Optional<string?> IPartialUser.GlobalName => this.GlobalName;
 
     /// <inheritdoc/>
     Optional<IImageHash?> IPartialUser.Avatar => new(this.Avatar);

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUser.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUser.cs
@@ -57,7 +57,7 @@ public interface IUser : IPartialUser
     /// </summary>
     /// <remarks>
     /// Intentionally not implemented as this field is not present in Discord's OpenAPI specification.
-    /// Despite being documented, it is not fully implemented and is not returned by many endpoints
+    /// Despite being documented, it is not fully implemented and is not returned by many endpoints.
     /// </remarks>
     // new string? GlobalName { get; }
 

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUserMention.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUserMention.cs
@@ -28,6 +28,7 @@ namespace Remora.Discord.API.Abstractions.Objects;
 /// <summary>
 /// Represents a user mention.
 /// </summary>
+/// <inheritdoc cref="IUser" path="/remarks"/>
 [PublicAPI]
 public interface IUserMention : IUser
 {

--- a/Backend/Remora.Discord.API/API/Gateway/Events/Users/UserUpdate.cs
+++ b/Backend/Remora.Discord.API/API/Gateway/Events/Users/UserUpdate.cs
@@ -35,7 +35,8 @@ public record UserUpdate
     Snowflake ID,
     string Username,
     ushort Discriminator,
-    string? GlobalName,
+    // GlobalName is not present in the OpenAPI spec, only in documentation and is not returned by all endpoints
+    // Optional<string?> GlobalName,
     IImageHash? Avatar,
     Optional<bool> IsBot = default,
     Optional<bool> IsSystem = default,

--- a/Backend/Remora.Discord.API/API/Gateway/Events/Users/UserUpdate.cs
+++ b/Backend/Remora.Discord.API/API/Gateway/Events/Users/UserUpdate.cs
@@ -35,8 +35,6 @@ public record UserUpdate
     Snowflake ID,
     string Username,
     ushort Discriminator,
-    // GlobalName is not present in the OpenAPI spec, only in documentation and is not returned by all endpoints
-    // Optional<string?> GlobalName,
     IImageHash? Avatar,
     Optional<bool> IsBot = default,
     Optional<bool> IsSystem = default,

--- a/Backend/Remora.Discord.API/API/Objects/Users/PartialUser.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Users/PartialUser.cs
@@ -36,7 +36,6 @@ public record PartialUser
     Optional<Snowflake> ID = default,
     Optional<string> Username = default,
     Optional<ushort> Discriminator = default,
-    // Optional<string?> GlobalName = default,
     Optional<IImageHash?> Avatar = default,
     Optional<bool> IsBot = default,
     Optional<bool> IsSystem = default,

--- a/Backend/Remora.Discord.API/API/Objects/Users/PartialUser.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Users/PartialUser.cs
@@ -36,7 +36,7 @@ public record PartialUser
     Optional<Snowflake> ID = default,
     Optional<string> Username = default,
     Optional<ushort> Discriminator = default,
-    Optional<string?> GlobalName = default,
+    // Optional<string?> GlobalName = default,
     Optional<IImageHash?> Avatar = default,
     Optional<bool> IsBot = default,
     Optional<bool> IsSystem = default,

--- a/Backend/Remora.Discord.API/API/Objects/Users/User.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Users/User.cs
@@ -36,7 +36,7 @@ public record User
     Snowflake ID,
     string Username,
     ushort Discriminator,
-    string? GlobalName,
+    // string? GlobalName,
     IImageHash? Avatar,
     Optional<bool> IsBot = default,
     Optional<bool> IsSystem = default,

--- a/Backend/Remora.Discord.API/API/Objects/Users/User.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Users/User.cs
@@ -36,7 +36,6 @@ public record User
     Snowflake ID,
     string Username,
     ushort Discriminator,
-    // string? GlobalName,
     IImageHash? Avatar,
     Optional<bool> IsBot = default,
     Optional<bool> IsSystem = default,

--- a/Backend/Remora.Discord.API/API/Objects/Users/UserMention.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Users/UserMention.cs
@@ -34,7 +34,7 @@ public record UserMention
     Snowflake ID,
     string Username,
     ushort Discriminator,
-    string? GlobalName,
+    // string? GlobalName,
     IImageHash? Avatar,
     Optional<bool> IsBot = default,
     Optional<bool> IsSystem = default,

--- a/Backend/Remora.Discord.API/API/Objects/Users/UserMention.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Users/UserMention.cs
@@ -34,7 +34,6 @@ public record UserMention
     Snowflake ID,
     string Username,
     ushort Discriminator,
-    // string? GlobalName,
     IImageHash? Avatar,
     Optional<bool> IsBot = default,
     Optional<bool> IsSystem = default,

--- a/Tests/Remora.Discord.Gateway.Tests/Constants.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Constants.cs
@@ -39,7 +39,6 @@ public static class Constants
         DiscordSnowflake.New(0),
         "mock_bot",
         0,
-        "mock-bot",
         null
     );
 

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_CREATE/CHANNEL_CREATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_CREATE/CHANNEL_CREATE.json
@@ -26,7 +26,6 @@
             {
                 "username": "none",
                 "discriminator": "9999",
-                "global_name": "none",
                 "id": "999999999999999999",
                 "avatar": "68b329da9893e34099c7d8ad5cb9c940"
             }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_CREATE/CHANNEL_CREATE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_CREATE/CHANNEL_CREATE.nulls.json
@@ -26,7 +26,6 @@
             {
                 "username": "none",
                 "discriminator": "9999",
-                "global_name": "none",
                 "id": "999999999999999999",
                 "avatar": "68b329da9893e34099c7d8ad5cb9c940"
             }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_DELETE/CHANNEL_DELETE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_DELETE/CHANNEL_DELETE.json
@@ -26,7 +26,6 @@
             {
                 "username": "none",
                 "discriminator": "9999",
-                "global_name": "none",
                 "id": "999999999999999999",
                 "avatar": "68b329da9893e34099c7d8ad5cb9c940"
             }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_DELETE/CHANNEL_DELETE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_DELETE/CHANNEL_DELETE.nulls.json
@@ -26,7 +26,6 @@
             {
                 "username": "none",
                 "discriminator": "9999",
-                "global_name": "none",
                 "id": "999999999999999999",
                 "avatar": "68b329da9893e34099c7d8ad5cb9c940"
             }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_UPDATE/CHANNEL_UPDATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_UPDATE/CHANNEL_UPDATE.json
@@ -26,7 +26,6 @@
             {
                 "username": "none",
                 "discriminator": "9999",
-                "global_name": "none",
                 "id": "999999999999999999",
                 "avatar": "68b329da9893e34099c7d8ad5cb9c940"
             }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_UPDATE/CHANNEL_UPDATE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/CHANNEL_UPDATE/CHANNEL_UPDATE.nulls.json
@@ -26,7 +26,6 @@
             {
                 "username": "none",
                 "discriminator": "9999",
-                "global_name": "none",
                 "id": "999999999999999999",
                 "avatar": "68b329da9893e34099c7d8ad5cb9c940"
             }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_BAN_ADD/GUILD_BAN_ADD.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_BAN_ADD/GUILD_BAN_ADD.json
@@ -8,7 +8,6 @@
       "id": "999999999999999999",
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     }
   }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_BAN_REMOVE/GUILD_BAN_REMOVE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_BAN_REMOVE/GUILD_BAN_REMOVE.json
@@ -8,7 +8,6 @@
       "id": "999999999999999999",
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     }
   }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_MEMBER_REMOVE/GUILD_MEMBER_REMOVE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_MEMBER_REMOVE/GUILD_MEMBER_REMOVE.json
@@ -7,7 +7,6 @@
       "id": "999999999999999999",
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
     "guild_id": "999999999999999999"

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_MEMBER_UPDATE/GUILD_MEMBER_UPDATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_MEMBER_UPDATE/GUILD_MEMBER_UPDATE.json
@@ -11,7 +11,6 @@
       "id": "999999999999999999",
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
     "nick": "none",

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_MEMBER_UPDATE/GUILD_MEMBER_UPDATE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_MEMBER_UPDATE/GUILD_MEMBER_UPDATE.nulls.json
@@ -11,7 +11,6 @@
       "id": "999999999999999999",
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
     "nick": null,

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_MEMBER_UPDATE/GUILD_MEMBER_UPDATE.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_MEMBER_UPDATE/GUILD_MEMBER_UPDATE.optionals.json
@@ -11,7 +11,6 @@
       "id": "999999999999999999",
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
     "avatar": "68b329da9893e34099c7d8ad5cb9c940",

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_CREATE/GUILD_SCHEDULED_EVENT_CREATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_CREATE/GUILD_SCHEDULED_EVENT_CREATE.json
@@ -19,7 +19,6 @@
     "creator": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_CREATE/GUILD_SCHEDULED_EVENT_CREATE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_CREATE/GUILD_SCHEDULED_EVENT_CREATE.nulls.json
@@ -19,7 +19,6 @@
     "creator": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_DELETE/GUILD_SCHEDULED_EVENT_DELETE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_DELETE/GUILD_SCHEDULED_EVENT_DELETE.json
@@ -19,7 +19,6 @@
     "creator": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_DELETE/GUILD_SCHEDULED_EVENT_DELETE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_DELETE/GUILD_SCHEDULED_EVENT_DELETE.nulls.json
@@ -19,7 +19,6 @@
     "creator": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_UPDATE/GUILD_SCHEDULED_EVENT_UPDATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_UPDATE/GUILD_SCHEDULED_EVENT_UPDATE.json
@@ -19,7 +19,6 @@
     "creator": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_UPDATE/GUILD_SCHEDULED_EVENT_UPDATE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/GUILD_SCHEDULED_EVENT_UPDATE/GUILD_SCHEDULED_EVENT_UPDATE.nulls.json
@@ -19,7 +19,6 @@
     "creator": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/INTEGRATION_CREATE/INTEGRATION_CREATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/INTEGRATION_CREATE/INTEGRATION_CREATE.json
@@ -15,7 +15,6 @@
     "user": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/INTEGRATION_UPDATE/INTEGRATION_UPDATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/INTEGRATION_UPDATE/INTEGRATION_UPDATE.json
@@ -15,7 +15,6 @@
     "user": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/INTERACTION_CREATE/INTERACTION_CREATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/INTERACTION_CREATE/INTERACTION_CREATE.json
@@ -25,7 +25,6 @@
     "user": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
@@ -37,7 +36,6 @@
       "author": {
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "id": "999999999999999999",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940"
       },

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/INVITE_CREATE/INVITE_CREATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/INVITE_CREATE/INVITE_CREATE.json
@@ -11,7 +11,6 @@
       "id": "999999999999999999",
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
     "max_age": 1,

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_CREATE/MESSAGE_CREATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_CREATE/MESSAGE_CREATE.json
@@ -8,7 +8,6 @@
     "author": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
@@ -64,7 +63,6 @@
       "author": {
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "id": "999999999999999999",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940"
       },
@@ -87,7 +85,6 @@
       "user": {
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "id": "999999999999999999",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940"
       }
@@ -117,7 +114,6 @@
         "id": "999999999999999999",
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940",
         "member": {}
       }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_CREATE/MESSAGE_CREATE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_CREATE/MESSAGE_CREATE.nulls.json
@@ -8,7 +8,6 @@
     "author": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
@@ -66,7 +65,6 @@
       "user": {
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "id": "999999999999999999",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940"
       }
@@ -95,7 +93,6 @@
         "id": "999999999999999999",
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940",
         "member": {}
       }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_CREATE/MESSAGE_CREATE.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_CREATE/MESSAGE_CREATE.optionals.json
@@ -8,7 +8,6 @@
     "author": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
@@ -40,7 +39,6 @@
         "id": "999999999999999999",
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940",
         "member": {}
       }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_UPDATE/MESSAGE_UPDATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_UPDATE/MESSAGE_UPDATE.json
@@ -8,7 +8,6 @@
     "author": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
@@ -64,7 +63,6 @@
       "author": {
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "id": "999999999999999999",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940"
       },
@@ -87,7 +85,6 @@
       "user": {
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "id": "999999999999999999",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940"
       }
@@ -117,7 +114,6 @@
         "id": "999999999999999999",
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940",
         "member": {}
       }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_UPDATE/MESSAGE_UPDATE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_UPDATE/MESSAGE_UPDATE.nulls.json
@@ -8,7 +8,6 @@
     "author": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
@@ -66,7 +65,6 @@
       "user": {
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "id": "999999999999999999",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940"
       }
@@ -95,7 +93,6 @@
         "id": "999999999999999999",
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940",
         "member": {}
       }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_UPDATE/MESSAGE_UPDATE.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/MESSAGE_UPDATE/MESSAGE_UPDATE.optionals.json
@@ -11,7 +11,6 @@
         "id": "999999999999999999",
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940",
         "member": { }
       }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/READY/READY.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/READY/READY.json
@@ -6,7 +6,6 @@
       "id": "999999999999999999",
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
     "guilds": [

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/READY/READY.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/READY/READY.optionals.json
@@ -6,7 +6,6 @@
       "id": "999999999999999999",
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
     "guilds": [

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/THREAD_CREATE/THREAD_CREATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/THREAD_CREATE/THREAD_CREATE.json
@@ -26,7 +26,6 @@
       {
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "id": "999999999999999999",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940"
       }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/THREAD_CREATE/THREAD_CREATE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/THREAD_CREATE/THREAD_CREATE.nulls.json
@@ -26,7 +26,6 @@
       {
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "id": "999999999999999999",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940"
       }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/THREAD_UPDATE/THREAD_UPDATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/THREAD_UPDATE/THREAD_UPDATE.json
@@ -26,7 +26,6 @@
       {
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "id": "999999999999999999",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940"
       }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/THREAD_UPDATE/THREAD_UPDATE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/THREAD_UPDATE/THREAD_UPDATE.nulls.json
@@ -26,7 +26,6 @@
       {
         "username": "none",
         "discriminator": "9999",
-        "global_name": "none",
         "id": "999999999999999999",
         "avatar": "68b329da9893e34099c7d8ad5cb9c940"
       }

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/USER_UPDATE/USER_UPDATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/USER_UPDATE/USER_UPDATE.json
@@ -6,7 +6,6 @@
     "id": "999999999999999999",
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940",
     "bot": true,
     "system": true,

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/USER_UPDATE/USER_UPDATE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/USER_UPDATE/USER_UPDATE.nulls.json
@@ -6,7 +6,6 @@
     "id": "999999999999999999",
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "avatar": null,
     "bot": true,
     "system": true,

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/USER_UPDATE/USER_UPDATE.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/USER_UPDATE/USER_UPDATE.optionals.json
@@ -6,7 +6,6 @@
     "id": "999999999999999999",
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   }
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/APPLICATION_COMMAND_INTERACTION_DATA_RESOLVED/APPLICATION_COMMAND_INTERACTION_DATA_RESOLVED.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/APPLICATION_COMMAND_INTERACTION_DATA_RESOLVED/APPLICATION_COMMAND_INTERACTION_DATA_RESOLVED.json
@@ -4,7 +4,6 @@
       "id": "999999999999999999",
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "avatar": null
     }
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/AUDIT_LOG/AUDIT_LOG.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/AUDIT_LOG/AUDIT_LOG.json
@@ -68,7 +68,6 @@
         {
             "avatar": "68b329da9893e34099c7d8ad5cb9c940",
             "discriminator": "9999",
-            "global_name": "none",
             "id": "999999999999999999",
             "username": "none"
         }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/AUTHORIZATION_INFORMATION/AUTHORIZATION_INFORMATION.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/AUTHORIZATION_INFORMATION/AUTHORIZATION_INFORMATION.json
@@ -7,7 +7,6 @@
   "user": {
     "avatar": "68b329da9893e34099c7d8ad5cb9c940",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "username": "none"
   }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/BAN/BAN.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/BAN/BAN.json
@@ -3,7 +3,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/BAN/BAN.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/BAN/BAN.nulls.json
@@ -3,7 +3,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/CHANNEL/CHANNEL.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/CHANNEL/CHANNEL.json
@@ -22,7 +22,6 @@
     {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/CHANNEL/CHANNEL.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/CHANNEL/CHANNEL.nulls.json
@@ -22,7 +22,6 @@
     {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/EMOJI/EMOJI.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/EMOJI/EMOJI.json
@@ -7,7 +7,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/EMOJI/EMOJI.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/EMOJI/EMOJI.nulls.json
@@ -7,7 +7,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_MEMBER/GUILD_MEMBER.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_MEMBER/GUILD_MEMBER.json
@@ -2,7 +2,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_MEMBER/GUILD_MEMBER.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_MEMBER/GUILD_MEMBER.nulls.json
@@ -2,7 +2,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_SCHEDULED_EVENT/GUILD_SCHEDULED_EVENT.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_SCHEDULED_EVENT/GUILD_SCHEDULED_EVENT.json
@@ -15,7 +15,6 @@
   "creator": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_SCHEDULED_EVENT/GUILD_SCHEDULED_EVENT.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_SCHEDULED_EVENT/GUILD_SCHEDULED_EVENT.nulls.json
@@ -15,7 +15,6 @@
   "creator": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_SCHEDULED_EVENT_USER/GUILD_SCHEDULED_EVENT_USER.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_SCHEDULED_EVENT_USER/GUILD_SCHEDULED_EVENT_USER.json
@@ -3,7 +3,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_SCHEDULED_EVENT_USER/GUILD_SCHEDULED_EVENT_USER.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/GUILD_SCHEDULED_EVENT_USER/GUILD_SCHEDULED_EVENT_USER.optionals.json
@@ -3,7 +3,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/INTEGRATION/INTEGRATION.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/INTEGRATION/INTEGRATION.json
@@ -11,7 +11,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/INTERACTION/INTERACTION.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/INTERACTION/INTERACTION.json
@@ -21,7 +21,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },
@@ -33,7 +32,6 @@
     "author": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/INVITE/INVITE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/INVITE/INVITE.json
@@ -5,7 +5,6 @@
   "inviter": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },
@@ -13,7 +12,6 @@
   "target_user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },
@@ -38,7 +36,6 @@
           "user": {
             "avatar": "68b329da9893e34099c7d8ad5cb9c940",
             "discriminator": "9999",
-            "global_name": "none",
             "id": "999999999999999999",
             "username": "none"
           }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/INVITE/INVITE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/INVITE/INVITE.nulls.json
@@ -5,7 +5,6 @@
   "inviter": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },
@@ -13,7 +12,6 @@
   "target_user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },
@@ -38,7 +36,6 @@
           "user": {
             "avatar": "68b329da9893e34099c7d8ad5cb9c940",
             "discriminator": "9999",
-            "global_name": "none",
             "id": "999999999999999999",
             "username": "none"
           }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE/MESSAGE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE/MESSAGE.json
@@ -4,7 +4,6 @@
   "author": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },
@@ -17,7 +16,6 @@
     {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     }
@@ -69,7 +67,6 @@
     "author": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     },
@@ -92,7 +89,6 @@
     "user": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE/MESSAGE.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE/MESSAGE.nulls.json
@@ -4,7 +4,6 @@
   "author": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },
@@ -17,7 +16,6 @@
     {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     }
@@ -71,7 +69,6 @@
     "user": {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE/MESSAGE.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE/MESSAGE.optionals.json
@@ -4,7 +4,6 @@
   "author": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },
@@ -17,7 +16,6 @@
     {
       "username": "none",
       "discriminator": "9999",
-      "global_name": "none",
       "id": "999999999999999999",
       "avatar": "68b329da9893e34099c7d8ad5cb9c940"
     }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_INTERACTION/MESSAGE_INTERACTION.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_INTERACTION/MESSAGE_INTERACTION.json
@@ -5,7 +5,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_INTERACTION/MESSAGE_INTERACTION.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/MESSAGE_INTERACTION/MESSAGE_INTERACTION.optionals.json
@@ -5,7 +5,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/STICKER/STICKER.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/STICKER/STICKER.json
@@ -11,7 +11,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/STICKER/STICKER.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/STICKER/STICKER.nulls.json
@@ -11,7 +11,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/TEMPLATE/TEMPLATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/TEMPLATE/TEMPLATE.json
@@ -9,7 +9,6 @@
     "username": "none",
     "avatar": null,
     "discriminator": "9999",
-    "global_name": "none",
     "public_flags": 0,
     "bot": true
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/USER/USER.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/USER/USER.json
@@ -2,7 +2,6 @@
   "id": "999999999999999999",
   "username": "none",
   "discriminator": "9999",
-  "global_name": "none",
   "avatar": "68b329da9893e34099c7d8ad5cb9c940",
   "bot": true,
   "system": true,

--- a/Tests/Remora.Discord.Tests/Samples/Objects/USER/USER.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/USER/USER.nulls.json
@@ -2,7 +2,6 @@
   "id": "999999999999999999",
   "username": "none",
   "discriminator": "9999",
-  "global_name": null,
   "avatar": null,
   "bot": true,
   "system": true,

--- a/Tests/Remora.Discord.Tests/Samples/Objects/USER/USER.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/USER/USER.optionals.json
@@ -2,6 +2,5 @@
   "id": "999999999999999999",
   "username": "none",
   "discriminator": "9999",
-  "global_name": "none",
   "avatar": "68b329da9893e34099c7d8ad5cb9c940"
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/USER_MENTION/USER_MENTION.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/USER_MENTION/USER_MENTION.json
@@ -2,7 +2,6 @@
   "id": "999999999999999999",
   "username": "none",
   "discriminator": "9999",
-  "global_name": "none",
   "avatar": "68b329da9893e34099c7d8ad5cb9c940",
   "bot": true,
   "system": true,

--- a/Tests/Remora.Discord.Tests/Samples/Objects/USER_MENTION/USER_MENTION.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/USER_MENTION/USER_MENTION.nulls.json
@@ -2,7 +2,6 @@
   "id": "999999999999999999",
   "username": "none",
   "discriminator": "9999",
-  "global_name": "none",
   "avatar": null,
   "bot": true,
   "system": true,

--- a/Tests/Remora.Discord.Tests/Samples/Objects/USER_MENTION/USER_MENTION.optionals.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/USER_MENTION/USER_MENTION.optionals.json
@@ -2,7 +2,6 @@
   "id": "999999999999999999",
   "username": "none",
   "discriminator": "9999",
-  "global_name": "none",
   "avatar": "68b329da9893e34099c7d8ad5cb9c940",
   "member": { }
 }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/WEBHOOK/WEBHOOK.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/WEBHOOK/WEBHOOK.json
@@ -6,7 +6,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },

--- a/Tests/Remora.Discord.Tests/Samples/Objects/WEBHOOK/WEBHOOK.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/WEBHOOK/WEBHOOK.nulls.json
@@ -6,7 +6,6 @@
   "user": {
     "username": "none",
     "discriminator": "9999",
-    "global_name": "none",
     "id": "999999999999999999",
     "avatar": "68b329da9893e34099c7d8ad5cb9c940"
   },


### PR DESCRIPTION
The spec as defined by https://github.com/discord/discord-api-spec/blob/main/specs/openapi.json
Resolves issue #313 
Wasn't sure how to mark it as intentionally left out so let me know if I should change that (or if anyone else wants to just fix it go for it). I also have generated patch files that could revert this once discord actually implements global_name fully, though I assume those could also be generate after the fact just from this pr.