### PR TITLE
Do not use IsDefined when updating cached nullable properties in GuildMember

### DIFF
--- a/Backend/Remora.Discord.Caching/Responders/EarlyCacheResponder.cs
+++ b/Backend/Remora.Discord.Caching/Responders/EarlyCacheResponder.cs
@@ -186,11 +186,11 @@ public class EarlyCacheResponder :
             cachedInstance = new GuildMember
             (
                 new Optional<IUser>(gatewayEvent.User),
-                gatewayEvent.Nickname.IsDefined(out var nickname) ? nickname : cachedInstance.Nickname,
+                gatewayEvent.Nickname.TryGet(out var nickname) ? nickname : cachedInstance.Nickname,
                 gatewayEvent.Avatar,
                 gatewayEvent.Roles,
                 gatewayEvent.JoinedAt ?? cachedInstance.JoinedAt,
-                gatewayEvent.PremiumSince.IsDefined(out var premiumSince) ? premiumSince : cachedInstance.PremiumSince,
+                gatewayEvent.PremiumSince.TryGet(out var premiumSince) ? premiumSince : cachedInstance.PremiumSince,
                 gatewayEvent.IsDeafened.TryGet(out var isDeafened) ? isDeafened : cachedInstance.IsDeafened,
                 gatewayEvent.IsMuted.TryGet(out var isMuted) ? isMuted : cachedInstance.IsMuted,
                 default, // TODO: this is probably on this event, but Discord hasn't documented it


### PR DESCRIPTION
Fixes an issue that would cause some properties to not be null after updating even if the new property was null. `IsDefined` checks if 1) the value exists and 2) the value *is not null*. The second check causes problems, that's why I replaced it with `TryGet` which only cares about a value being present, regardless of whether it's null or not