### PR TITLE
Fix that the initial message in the pagination doesn't use the footer…

### DIFF
--- a/Remora.Discord.Pagination/Extensions/FeedbackServiceExtensions.cs
+++ b/Remora.Discord.Pagination/Extensions/FeedbackServiceExtensions.cs
@@ -93,7 +93,7 @@ public static class FeedbackServiceExtensions
         var send = await feedback.SendEmbedAsync
         (
             channel,
-            pages[0] with { Footer = new EmbedFooter($"Page 1/{pages.Count}") },
+            data.GetCurrentPage(),
             options,
             ct
         );
@@ -160,7 +160,7 @@ public static class FeedbackServiceExtensions
 
         var send = await feedback.SendContextualEmbedAsync
         (
-            pages[0] with { Footer = new EmbedFooter($"Page 1/{pages.Count}") },
+            data.GetCurrentPage(),
             options,
             ct
         );
@@ -226,7 +226,7 @@ public static class FeedbackServiceExtensions
         var send = await feedback.SendPrivateEmbedAsync
         (
             user,
-            pages[0] with { Footer = new EmbedFooter($"Page 1/{pages.Count}") },
+            data.GetCurrentPage(),
             options,
             ct
         );


### PR DESCRIPTION
This fixes that the footer isn't used and it does make more sense to get the page from the data

Before:
![image](https://github.com/Remora/Remora.Discord/assets/46032261/be5892f9-c9a5-49e8-8676-9ceeac057a8e)
![image](https://github.com/Remora/Remora.Discord/assets/46032261/88b32151-08f0-4da5-bcb8-dca8f259f0da)

After:

![image](https://github.com/Remora/Remora.Discord/assets/46032261/d540ad4b-f492-4429-9e54-d0dada81bb11)
![image](https://github.com/Remora/Remora.Discord/assets/46032261/0b0a93fe-8b66-4cbf-a0a8-54db8d0334f6)
