### PR TITLE
fix(api): Fix InteractionContextType values

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/InteractionContextType.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/InteractionContextType.cs
@@ -33,15 +33,15 @@ public enum InteractionContextType
     /// <summary>
     /// The interaction was executed in the context of a guild.
     /// </summary>
-    Guild = 1,
+    Guild = 0,
 
     /// <summary>
     /// The interaction was executed in the context of a direct message to the bot associated with the application.
     /// </summary>
-    BotDM = 2,
+    BotDM = 1,
 
     /// <summary>
     /// The interaction was executed in the context of a direct message or group direct message.
     /// </summary>
-    PrivateChannel = 3,
+    PrivateChannel = 2,
 }


### PR DESCRIPTION
The enum values were off-by-one, causing HTTP 400 at registration.