### PR TITLE
fix(commands): Fix handling of pulling context

### DIFF
--- a/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -237,6 +237,7 @@ public static class ServiceCollectionExtensions
             .AddParser<EmojiParser>()
             .AddParser<GuildMemberParser>()
             .AddParser<MessageParser>()
+            .AddParser<PartialMessageParser>()
             .AddParser<RoleParser>()
             .AddParser<UserParser>();
 

--- a/Remora.Discord.Commands/Parsers/PartialMessageParser.cs
+++ b/Remora.Discord.Commands/Parsers/PartialMessageParser.cs
@@ -1,0 +1,92 @@
+//
+//  PartialMessageParser.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Remora.Commands.Parsers;
+using Remora.Discord.API;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Commands.Contexts;
+using Remora.Discord.Commands.Extensions;
+using Remora.Results;
+
+namespace Remora.Discord.Commands.Parsers;
+
+/// <summary>
+/// Parses instances of <see cref="IPartialMessage"/> from command-line inputs.
+/// </summary>
+[PublicAPI]
+public class PartialMessageParser : AbstractTypeParser<IPartialMessage>
+{
+    private readonly IInteractionContext? _context;
+    private readonly ITypeParser<IMessage> _messageParser;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PartialMessageParser"/> class.
+    /// </summary>
+    /// <param name="context">The interaction context, if available. </param>
+    /// <param name="messageParser">The message parser to delegate to, if necessary.</param>
+    public PartialMessageParser(IInteractionContext? context, ITypeParser<IMessage> messageParser)
+    {
+        _context = context;
+        _messageParser = messageParser;
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask<Result<IPartialMessage>> TryParseAsync
+    (
+        string value,
+        CancellationToken ct = default
+    )
+    {
+        var resolvedValue = ResolveMessageFromContext(value);
+
+        return resolvedValue is not null ? Result<IPartialMessage>.FromSuccess(resolvedValue) : (await _messageParser.TryParseAsync(value, ct)).Map<IPartialMessage>(m => m);
+    }
+
+    private IPartialMessage? ResolveMessageFromContext(string value)
+    {
+        if (_context is null)
+        {
+            return null;
+        }
+
+        if (!DiscordSnowflake.TryParse(value.Unmention(), out var messageID))
+        {
+            return null;
+        }
+
+        if (!_context.Interaction.Data.TryGet(out var interactionData) || interactionData.TryPickT0(out var strongData, out _))
+        {
+            return null;
+        }
+
+        if (!strongData.Resolved.TryGet(out var resolved) || !resolved.Messages.TryGet(out var messages))
+        {
+            return null;
+        }
+
+        _ = messages.TryGetValue(messageID.Value, out var message);
+        return message;
+    }
+}


### PR DESCRIPTION
This PR fixes an issue wherein Remora would not correctly pull from the context when resolving partial messages. This poses an issue where the user cannot access member information via the API (e.g., an HTTP bot).

The issue in question is that when presented with an `IPartialMessage` parameter, the parser will *always* attempt to resolve the message via REST, which, under normal circumstances *would* be fine; this is generally desirable behavior for text commands, but is detrimental to slash commands, and especially context menus where this is enforced (e.g., you *must* have the message parameter.)

Regardless, there is a very simple fix, but before that I wanted to explain why this is an issue to being with.

---

The issue doesn't lie in the actual API logic, but the delegation to the "base" implementation of the class. 

The reason this happens is because of type erasure; more specifically the `object` overloads on parsers, which are abstracted away by `AbstractTypeParser<TParser>`, which is how this bug arose to begin with. Remora doesn't invoke the generic method at runtime despite Remora.Commands [checking for parser types by the service-locator pattern](https://github.com/Remora/Remora.Commands/blob/8a8171abd5beac8c253e7f3da0453c4241f8d363/Remora.Commands/Services/TypeParserService.cs#L162-L173), and instead invokes the [type-erased](https://github.com/Remora/Remora.Commands/blob/main/Remora.Commands/Parsers/AbstractTypeParser.cs#L64-L71) method, which could really do anything.