### PR TITLE
Add invite metadata to guild invites response

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IInviteWithMetadata.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IInviteWithMetadata.cs
@@ -1,0 +1,56 @@
+//
+//  IInviteWithMetadata.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents an invite with metadata.
+/// </summary>
+public interface IInviteWithMetadata : IInvite
+{
+    /// <summary>
+    /// Gets the number of uses for this invite.
+    /// </summary>
+    int Uses { get; }
+
+    /// <summary>
+    /// Gets the maximum number of uses for this invite.
+    /// </summary>
+    int MaxUses { get; }
+
+    /// <summary>
+    /// Gets the duration (in seconds) after which the invite expires.
+    /// </summary>
+    int MaxAge { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this invite only grants temporary membership.
+    /// </summary>
+    bool IsTemporary { get; }
+
+    /// <summary>
+    /// Gets when this invite was created.
+    /// </summary>
+    DateTimeOffset CreatedAt { get; }
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IInviteWithMetadata.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IInviteWithMetadata.cs
@@ -42,7 +42,7 @@ public interface IInviteWithMetadata : IInvite
     /// <summary>
     /// Gets the duration (in seconds) after which the invite expires.
     /// </summary>
-    int MaxAge { get; }
+    TimeSpan MaxAge { get; }
 
     /// <summary>
     /// Gets a value indicating whether this invite only grants temporary membership.

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestGuildAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestGuildAPI.cs
@@ -923,7 +923,7 @@ public interface IDiscordRestGuildAPI
     /// <param name="guildID">The ID of the guild.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
     /// <returns>A retrieval result which may or may not have succeeded.</returns>
-    Task<Result<IReadOnlyList<IInvite>>> GetGuildInvitesAsync
+    Task<Result<IReadOnlyList<IInviteWithMetadata>>> GetGuildInvitesAsync
     (
         Snowflake guildID,
         CancellationToken ct = default

--- a/Backend/Remora.Discord.API/API/Objects/Invites/InviteWithMetadata.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Invites/InviteWithMetadata.cs
@@ -34,7 +34,7 @@ public record InviteWithMetadata
     IPartialChannel? Channel,
     int Uses,
     int MaxUses,
-    int MaxAge,
+    TimeSpan MaxAge,
     bool IsTemporary,
     DateTimeOffset CreatedAt,
     Optional<IUser> Inviter = default,

--- a/Backend/Remora.Discord.API/API/Objects/Invites/InviteWithMetadata.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Invites/InviteWithMetadata.cs
@@ -1,0 +1,48 @@
+//
+//  InviteWithMetadata.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Objects;
+
+/// <inheritdoc cref="IInviteWithMetadata" />
+public record InviteWithMetadata
+(
+    string Code,
+    Optional<IPartialGuild> Guild,
+    IPartialChannel? Channel,
+    int Uses,
+    int MaxUses,
+    int MaxAge,
+    bool IsTemporary,
+    DateTimeOffset CreatedAt,
+    Optional<IUser> Inviter = default,
+    Optional<InviteTarget> TargetType = default,
+    Optional<IPartialUser> TargetUser = default,
+    Optional<IPartialApplication> TargetApplication = default,
+    Optional<int> ApproximatePresenceCount = default,
+    Optional<int> ApproximateMemberCount = default,
+    Optional<DateTimeOffset?> ExpiresAt = default,
+    Optional<IGuildScheduledEvent> GuildScheduledEvent = default
+) : IInviteWithMetadata;

--- a/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
@@ -780,6 +780,9 @@ public static class ServiceCollectionExtensions
     {
         options.AddDataObjectConverter<IInvite, Invite>();
         options.AddDataObjectConverter<IPartialInvite, PartialInvite>();
+        options.AddDataObjectConverter<IInviteWithMetadata, InviteWithMetadata>()
+            .WithPropertyName(i => i.IsTemporary, "temporary")
+            .WithPropertyConverter(i => i.MaxAge, new UnitTimeSpanConverter(TimeUnit.Seconds));
 
         return options;
     }

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestGuildAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestGuildAPI.cs
@@ -1005,14 +1005,14 @@ public partial class CachingDiscordRestGuildAPI : IDiscordRestGuildAPI, IRestCus
     }
 
     /// <inheritdoc />
-    public async Task<Result<IReadOnlyList<IInvite>>> GetGuildInvitesAsync
+    public async Task<Result<IReadOnlyList<IInviteWithMetadata>>> GetGuildInvitesAsync
     (
         Snowflake guildID,
         CancellationToken ct = default
     )
     {
         var collectionKey = new KeyHelpers.GuildInvitesCacheKey(guildID);
-        var cacheResult = await _cacheService.TryGetValueAsync<IReadOnlyList<IInvite>>(collectionKey, ct);
+        var cacheResult = await _cacheService.TryGetValueAsync<IReadOnlyList<IInviteWithMetadata>>(collectionKey, ct);
 
         if (cacheResult.IsSuccess)
         {

--- a/Backend/Remora.Discord.Rest/API/Guilds/DiscordRestGuildAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Guilds/DiscordRestGuildAPI.cs
@@ -1229,13 +1229,13 @@ public class DiscordRestGuildAPI : AbstractDiscordRestAPI, IDiscordRestGuildAPI
     }
 
     /// <inheritdoc />
-    public virtual Task<Result<IReadOnlyList<IInvite>>> GetGuildInvitesAsync
+    public virtual Task<Result<IReadOnlyList<IInviteWithMetadata>>> GetGuildInvitesAsync
     (
         Snowflake guildID,
         CancellationToken ct = default
     )
     {
-        return this.RestHttpClient.GetAsync<IReadOnlyList<IInvite>>
+        return this.RestHttpClient.GetAsync<IReadOnlyList<IInviteWithMetadata>>
         (
             $"guilds/{guildID}/invites",
             b => b.WithRateLimitContext(this.RateLimitCache),

--- a/Tests/Remora.Discord.API.Tests/API/Objects/Invites/InviteWithMetadataTests.cs
+++ b/Tests/Remora.Discord.API.Tests/API/Objects/Invites/InviteWithMetadataTests.cs
@@ -1,0 +1,39 @@
+//
+//  InviteWithMetadataTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Tests.TestBases;
+
+namespace Remora.Discord.API.Tests.Objects;
+
+/// <inheritdoc />
+public class InviteWithMetadataTests : ObjectTestBase<IInviteWithMetadata>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InviteWithMetadataTests"/> class.
+    /// </summary>
+    /// <param name="fixture">The test fixture.</param>
+    public InviteWithMetadataTests(JsonBackedTypeTestFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/INVITE_WITH_METADATA/INVITE_WITH_METADATA.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/INVITE_WITH_METADATA/INVITE_WITH_METADATA.json
@@ -1,0 +1,70 @@
+{
+  "code": "123456",
+  "guild": { },
+  "channel": { },
+  "inviter": {
+    "username": "none",
+    "discriminator": "9999",
+    "id": "999999999999999999",
+    "avatar": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "target_type": 1,
+  "target_user": {
+    "username": "none",
+    "discriminator": "9999",
+    "id": "999999999999999999",
+    "avatar": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "target_application": {
+    "id": "999999999999999999",
+    "name": "none",
+    "icon": "68b329da9893e34099c7d8ad5cb9c940",
+    "description": "none",
+    "bot_public": true,
+    "bot_require_code_grant": true,
+    "verify_key": "none",
+    "team": {
+      "icon": "68b329da9893e34099c7d8ad5cb9c940",
+      "id": "999999999999999999",
+      "members": [
+        {
+          "membership_state": 2,
+          "permissions": [
+            "*"
+          ],
+          "team_id": "999999999999999999",
+          "user": {
+            "avatar": "68b329da9893e34099c7d8ad5cb9c940",
+            "discriminator": "9999",
+            "id": "999999999999999999",
+            "username": "none"
+          },
+          "role": "read_only"
+        }
+      ],
+      "name": "none",
+      "owner_user_id": "999999999999999999"
+    }
+  },
+  "approximate_presence_count": 1,
+  "approximate_member_count": 1,
+  "expires_at": "1970-01-01T00:00:00.000000+00:00",
+  "guild_scheduled_event": {
+    "id": "999999999999999999",
+    "guild_id": "999999999999999999",
+    "channel_id": "999999999999999999",
+    "name": "none",
+    "scheduled_start_time": "1970-01-01T00:00:00.000000+00:00",
+    "scheduled_end_time": "1970-01-01T00:00:00.000000+00:00",
+    "privacy_level": 1,
+    "status": 1,
+    "entity_type": 1,
+    "entity_id": "999999999999999999",
+    "entity_metadata": { }
+  },
+  "uses": 1,
+  "max_uses": 1,
+  "max_age": 86400,
+  "temporary": true,
+  "created_at": "1970-01-01T00:00:00.000000+00:00"
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/INVITE_WITH_METADATA/INVITE_WITH_METADATA.nulls.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/INVITE_WITH_METADATA/INVITE_WITH_METADATA.nulls.json
@@ -1,0 +1,70 @@
+{
+  "code": "123456",
+  "guild": { },
+  "channel": null,
+  "inviter": {
+    "username": "none",
+    "discriminator": "9999",
+    "id": "999999999999999999",
+    "avatar": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "target_type": 1,
+  "target_user": {
+    "username": "none",
+    "discriminator": "9999",
+    "id": "999999999999999999",
+    "avatar": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "target_application": {
+    "id": "999999999999999999",
+    "name": "none",
+    "icon": "68b329da9893e34099c7d8ad5cb9c940",
+    "description": "none",
+    "bot_public": true,
+    "bot_require_code_grant": true,
+    "verify_key": "none",
+    "team": {
+      "icon": "68b329da9893e34099c7d8ad5cb9c940",
+      "id": "999999999999999999",
+      "members": [
+        {
+          "membership_state": 2,
+          "permissions": [
+            "*"
+          ],
+          "team_id": "999999999999999999",
+          "user": {
+            "avatar": "68b329da9893e34099c7d8ad5cb9c940",
+            "discriminator": "9999",
+            "id": "999999999999999999",
+            "username": "none"
+          },
+          "role": "read_only"
+        }
+      ],
+      "name": "none",
+      "owner_user_id": "999999999999999999"
+    }
+  },
+  "approximate_presence_count": 1,
+  "approximate_member_count": 1,
+  "expires_at": null,
+  "guild_scheduled_event": {
+    "id": "999999999999999999",
+    "guild_id": "999999999999999999",
+    "channel_id": "999999999999999999",
+    "name": "none",
+    "scheduled_start_time": "1970-01-01T00:00:00.000000+00:00",
+    "scheduled_end_time": "1970-01-01T00:00:00.000000+00:00",
+    "privacy_level": 1,
+    "status": 1,
+    "entity_type": 1,
+    "entity_id": "999999999999999999",
+    "entity_metadata": { }
+  },
+  "uses": 1,
+  "max_uses": 1,
+  "max_age": 86400,
+  "temporary": true,
+  "created_at": "1970-01-01T00:00:00.000000+00:00"
+}

--- a/Tests/Remora.Discord.Tests/Samples/Objects/INVITE_WITH_METADATA/INVITE_WITH_METADATA.options.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/INVITE_WITH_METADATA/INVITE_WITH_METADATA.options.json
@@ -1,0 +1,9 @@
+{
+  "code": "123456",
+  "channel": { },
+  "uses": 1,
+  "max_uses": 1,
+  "max_age": 86400,
+  "temporary": true,
+  "created_at": "1970-01-01T00:00:00.000000+00:00"
+}


### PR DESCRIPTION
Adds the keys in the invite metadata object (https://discord.com/developers/docs/resources/invite#invite-metadata-object) to the type returned by GET /guilds/{guildID}/invites.