### PR TITLE
Add array support for slash commands

### DIFF
--- a/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
@@ -37,7 +37,9 @@ using Remora.Discord.API.Objects;
 using Remora.Discord.Commands.Attributes;
 using Remora.Discord.Commands.Services;
 using Remora.Rest.Core;
+using Remora.Rest.Extensions;
 using static Remora.Discord.API.Abstractions.Objects.ApplicationCommandOptionType;
+using RangeAttribute = Remora.Commands.Attributes.RangeAttribute;
 
 namespace Remora.Discord.Commands.Extensions;
 
@@ -712,15 +714,15 @@ public static class CommandTreeExtensions
                         parameter
                     );
                 }
-                case NamedCollectionParameterShape or PositionalCollectionParameterShape:
-                {
-                    throw new UnsupportedParameterFeatureException
-                    (
-                        "Collection parameters are not supported in slash commands.",
-                        command,
-                        parameter
-                    );
-                }
+                // case NamedCollectionParameterShape or PositionalCollectionParameterShape:
+                // {
+                //     throw new UnsupportedParameterFeatureException
+                //     (
+                //         "Collection parameters are not supported in slash commands.",
+                //         command,
+                //         parameter
+                //     );
+                // }
             }
 
             var actualParameterType = parameter.GetActualParameterType();
@@ -739,26 +741,60 @@ public static class CommandTreeExtensions
 
             var (channelTypes, minValue, maxValue, minLength, maxLength) = GetParameterConstraints(command, parameter);
 
-            var parameterOption = new ApplicationCommandOption
-            (
-                parameter.GetDiscordType(),
-                name,
-                parameter.Description,
-                default,
-                !parameter.IsOmissible(),
-                choices,
-                ChannelTypes: channelTypes,
-                EnableAutocomplete: enableAutocomplete,
-                MinValue: minValue,
-                MaxValue: maxValue,
-                NameLocalizations: localizedNames.Count > 0 ? new(localizedNames) : default,
-                DescriptionLocalizations: localizedDescriptions.Count > 0 ? new(localizedDescriptions) : default,
-                MinLength: minLength,
-                MaxLength: maxLength
-            );
+            if (parameter is not (NamedCollectionParameterShape or PositionalCollectionParameterShape))
+            {
+                var parameterOption = new ApplicationCommandOption
+                (
+                    parameter.GetDiscordType(),
+                    name,
+                    parameter.Description,
+                    default,
+                    !parameter.IsOmissible(),
+                    choices,
+                    ChannelTypes: channelTypes,
+                    EnableAutocomplete: enableAutocomplete,
+                    MinValue: minValue,
+                    MaxValue: maxValue,
+                    NameLocalizations: localizedNames.Count > 0 ? new(localizedNames) : default,
+                    DescriptionLocalizations: localizedDescriptions.Count > 0 ? new(localizedDescriptions) : default,
+                    MinLength: minLength,
+                    MaxLength: maxLength
+                );
 
-            parameterOptions.Add(parameterOption);
+                parameterOptions.Add(parameterOption);
+
+                continue;
+            }
+
+            // Collection parameters
+            var rangeAttribute = parameter.Parameter.GetCustomAttribute<RangeAttribute>();
+            var (minElements, maxElements) = (rangeAttribute?.GetMin() ?? 1, rangeAttribute?.GetMax());
+
+            for (ulong i = 0; i < (maxElements ?? minElements); i++)
+            {
+                var parameterOption = new ApplicationCommandOption
+                (
+                    parameter.GetDiscordType(),
+                    $"{name}__{i + 1}",
+                    parameter.Description,
+                    default,
+                    i < minElements && !parameter.IsOmissible(),
+                    choices,
+                    ChannelTypes: channelTypes,
+                    EnableAutocomplete: enableAutocomplete,
+                    MinValue: minValue,
+                    MaxValue: maxValue,
+                    NameLocalizations: localizedNames.Count > 0 ? new(localizedNames) : default,
+                    DescriptionLocalizations: localizedDescriptions.Count > 0 ? new(localizedDescriptions) : default,
+                    MinLength: minLength,
+                    MaxLength: maxLength
+                );
+
+                parameterOptions.Add(parameterOption);
+            }
         }
+
+        parameterOptions = parameterOptions.OrderByDescending(p => p.IsRequired.OrDefault(true)).ToList();
 
         if (parameterOptions.Count > _maxCommandParameters)
         {

--- a/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
@@ -37,7 +37,6 @@ using Remora.Discord.API.Objects;
 using Remora.Discord.Commands.Attributes;
 using Remora.Discord.Commands.Services;
 using Remora.Rest.Core;
-using Remora.Rest.Extensions;
 using static Remora.Discord.API.Abstractions.Objects.ApplicationCommandOptionType;
 using RangeAttribute = Remora.Commands.Attributes.RangeAttribute;
 

--- a/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
@@ -714,15 +714,6 @@ public static class CommandTreeExtensions
                         parameter
                     );
                 }
-                // case NamedCollectionParameterShape or PositionalCollectionParameterShape:
-                // {
-                //     throw new UnsupportedParameterFeatureException
-                //     (
-                //         "Collection parameters are not supported in slash commands.",
-                //         command,
-                //         parameter
-                //     );
-                // }
             }
 
             var actualParameterType = parameter.GetActualParameterType();

--- a/Remora.Discord.Commands/Extensions/ParameterShapeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/ParameterShapeExtensions.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Remora.Commands.Extensions;
@@ -47,17 +48,23 @@ public static class ParameterShapeExtensions
     /// <returns>The actual type.</returns>
     public static Type GetActualParameterType(this IParameterShape shape, bool unwrapCollections = false)
     {
+        var parameterType = shape.Parameter.ParameterType;
+
         // IsCollection loves to inexplicably return false for IReadOnlyList<T> and friends, so we'll just do it manually
-        if (unwrapCollections && (shape.Parameter.ParameterType.IsArray || shape.Parameter.ParameterType.GetInterface(nameof(IEnumerable)) is not null))
+        if
+        (
+            unwrapCollections &&
+            parameterType != typeof(string) &&
+            (parameterType.IsArray || parameterType.GetInterface(nameof(IEnumerable)) is not null)
+        )
         {
-            return shape.Parameter.ParameterType.IsArray
-                ? shape.Parameter.ParameterType.GetElementType()!
-                : shape.Parameter.ParameterType.GetGenericArguments()[0];
+            return parameterType.IsArray
+                ? parameterType.GetElementType()!
+                : parameterType.GetGenericArguments()[0];
         }
 
         // Unwrap the parameter type if it's a Nullable<T> or Optional<T>
         // TODO: Maybe more cases?
-        var parameterType = shape.Parameter.ParameterType;
         return parameterType.IsNullable() || parameterType.IsOptional()
             ? parameterType.GetGenericArguments().Single()
             : parameterType;

--- a/Remora.Discord.Commands/Extensions/ParameterShapeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/ParameterShapeExtensions.cs
@@ -21,7 +21,6 @@
 //
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;

--- a/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
@@ -116,20 +116,6 @@ public class CommandTreeExtensionTests
             /// Tests whether the method responds appropriately to a failure case.
             /// </summary>
             [Fact]
-            public void ThrowsIfACommandContainsACollectionParameter()
-            {
-                var builder = new CommandTreeBuilder();
-                builder.RegisterModule<CollectionsAreNotSupported>();
-
-                var tree = builder.Build();
-
-                Assert.Throws<UnsupportedParameterFeatureException>(() => tree.CreateApplicationCommands());
-            }
-
-            /// <summary>
-            /// Tests whether the method responds appropriately to a failure case.
-            /// </summary>
-            [Fact]
             public void ThrowsIfACommandContainsASwitchParameter()
             {
                 var builder = new CommandTreeBuilder();


### PR DESCRIPTION
This commit changes how Remora.Discord.Commands maps slash commands, enabling support for arrays to be parsed and accepted, despite Discord STILL not having support for this.

For better or worse, a snippet of code had to be removed:

```cs
var collectionType = parameter.GetActualParameterType();

if (!collectionType.IsCollection() && !collectionType.IsArray)
{
    // Sanity check
    throw new InvalidOperationException("Collection parameter was not a collection.");
}
```
^ For some reason, `.IsCollection()` returns...false? I gave up on trying to figure out why that was the case - the code still works fine and there's other validity checks elsewhere.

BREAKING-CHANGE: Commands with the structure of `name__numbers` (e.g. `param__1`) are *no longer valid* and will get erased by the pre-parsing step that is a requisite to map arrays. This should be an absolutely niche case, but is still technically a breaking change, and should be documented as such.

Some other things of note:

- Attributes applied to the array apply to all elements in the array (this should go without saying, but hey)
- `[Range]` controls the array's length; `Min` = required, `Max` = Length
 - If Min < Max, `Min` elements will be required and `Max - Min` elements will be optional. Max will coalesce to Min when unspecified.
- Due to Discord's..questionable limitations, optional array parameters are placed at the end of the argument list for slash commands, but do preserve the order they're declared in relative to each other.

![image](https://github.com/user-attachments/assets/262eff93-20a6-4ad7-ab65-a8c73f577587)
