### PR TITLE
Samples: Fix user target resolution on feedback responses

### DIFF
--- a/Samples/Interactivity/Interactions/SelectMenuInteractions.cs
+++ b/Samples/Interactivity/Interactions/SelectMenuInteractions.cs
@@ -16,6 +16,7 @@ using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.API.Objects;
 using Remora.Discord.Commands.Contexts;
+using Remora.Discord.Commands.Extensions;
 using Remora.Discord.Commands.Feedback.Messages;
 using Remora.Discord.Commands.Feedback.Services;
 using Remora.Discord.Interactivity;
@@ -145,7 +146,7 @@ public partial class SelectMenuInteractions : InteractionGroup
         return (Result)await _feedback.SendContextualNeutralAsync
         (
             message,
-            _context.Interaction.User.TryGet(out var user) ? user.ID : default,
+            _context.TryGetUserID(out var userID) ? userID : default,
             options: new FeedbackMessageOptions(MessageFlags: MessageFlags.Ephemeral),
             ct: this.CancellationToken
         );
@@ -178,7 +179,7 @@ public partial class SelectMenuInteractions : InteractionGroup
         return (Result)await _feedback.SendContextualNeutralAsync
         (
             stringBuilder.ToString(),
-            _context.Interaction.User.TryGet(out var user) ? user.ID : default,
+            _context.TryGetUserID(out var userID) ? userID : default,
             options: new FeedbackMessageOptions
             (
                 MessageFlags: MessageFlags.Ephemeral,


### PR DESCRIPTION
A minor update to use the `OperationContextExtensions#TryGetUserID` extension to account for Discord's change to send user data in the `Member` field of an interaction response, rather than the `User` field.

Hence allowing the target of the feedback message to be reliably populated:
![image](https://github.com/user-attachments/assets/2b4fcbd2-b74d-43f6-b9bd-9429811b901d)
