### PR TITLE
Add custom buttons & ability to remove buttons to pagination

### DIFF
--- a/Remora.Discord.Pagination/Interactions/PaginationInteractions.cs
+++ b/Remora.Discord.Pagination/Interactions/PaginationInteractions.cs
@@ -175,6 +175,11 @@ internal class PaginationInteractions : InteractionGroup
         {
             return Result.FromSuccess();
         }
+        if (lease.Data.Appearance.HelpEmbed == null)
+        {
+            return new InvalidOperationError("Help embed is not available.");
+        }
+
         return (Result)await _feedback.SendContextualEmbedAsync
         (
             lease.Data.Appearance.HelpEmbed,

--- a/Remora.Discord.Pagination/PaginatedAppearanceOptions.cs
+++ b/Remora.Discord.Pagination/PaginatedAppearanceOptions.cs
@@ -37,10 +37,11 @@ public sealed record PaginatedAppearanceOptions
     ButtonComponent Previous,
     ButtonComponent Next,
     ButtonComponent Last,
-    ButtonComponent Close,
-    ButtonComponent Help,
-    Embed HelpEmbed,
-    string FooterFormat = "Page {0}/{1}"
+    ButtonComponent? Close,
+    ButtonComponent? Help,
+    Embed? HelpEmbed,
+    string FooterFormat = "Page {0}/{1}",
+    ButtonComponent[]? CustomButtons = null
 )
 {
     /// <summary>
@@ -94,7 +95,7 @@ public sealed record PaginatedAppearanceOptions
     /// <summary>
     /// Gets the appearance options' configured buttons as an array.
     /// </summary>
-    public IReadOnlyList<ButtonComponent> Buttons { get; } = new[]
+    public IReadOnlyList<ButtonComponent?> Buttons { get; } = new[]
     {
         First,
         Previous,

--- a/Remora.Discord.Pagination/PaginatedMessageData.cs
+++ b/Remora.Discord.Pagination/PaginatedMessageData.cs
@@ -156,6 +156,19 @@ internal sealed class PaginatedMessageData
     /// <returns>The buttons.</returns>
     public IReadOnlyList<IMessageComponent> GetCurrentComponents()
     {
+        List<ButtonComponent> customComponents = new List<ButtonComponent>();
+        if (this.Appearance.Help != null)
+        {
+            customComponents.Add(this.Appearance.Help with { CustomID = CustomIDHelpers.CreateButtonID("help") });
+        }
+        if (this.Appearance.Close != null)
+        {
+            customComponents.Add(this.Appearance.Close with { CustomID = CustomIDHelpers.CreateButtonID("close") });
+        }
+        if (this.Appearance.CustomButtons != null)
+        {
+            customComponents.AddRange(this.Appearance.CustomButtons);
+        }
         return new[]
         {
             new ActionRowComponent
@@ -186,11 +199,7 @@ internal sealed class PaginatedMessageData
             ),
             new ActionRowComponent
             (
-                new[]
-                {
-                    this.Appearance.Close with { CustomID = CustomIDHelpers.CreateButtonID("close") },
-                    this.Appearance.Help with { CustomID = CustomIDHelpers.CreateButtonID("help") }
-                }
+                customComponents
             )
         };
     }


### PR DESCRIPTION
This pr makes the help & close buttons nullable and doesn't show them when there null and it adds the ability to add custom buttons. 

I did this pr to allow for more customizabiltity when using the pagination, since there isn't always the need for a help and close button, but sometimes there is the need for other custom buttons on it.