### PR TITLE
fix(commands): Use .Shape for real command params.

### DIFF
--- a/Remora.Discord.Commands/Responders/AutocompleteResponder.cs
+++ b/Remora.Discord.Commands/Responders/AutocompleteResponder.cs
@@ -119,9 +119,9 @@ public class AutocompleteResponder : IResponder<IInteractionCreate>
             return new InvalidOperationError("Autocomplete interaction without focused option received. Desync?");
         }
 
-        var realParameter = commandNode.CommandMethod.GetParameters().First
+        var realParameter = commandNode.Shape.Parameters.First
         (
-            p => p.Name is not null && p.Name.Equals(focusedParameter.Name, StringComparison.OrdinalIgnoreCase)
+            p => p.Parameter.Name is not null && p.Parameter.Name.Equals(focusedParameter.Name, StringComparison.OrdinalIgnoreCase)
         );
 
         var contextInjector = _services.GetRequiredService<ContextInjectionService>();
@@ -131,7 +131,7 @@ public class AutocompleteResponder : IResponder<IInteractionCreate>
         IAutocompleteProvider? autocompleteProvider;
 
         // First, check if the parameter wants a specific provider
-        var providerAttribute = realParameter.GetCustomAttribute<AutocompleteProviderAttribute>();
+        var providerAttribute = realParameter.Parameter.GetCustomAttribute<AutocompleteProviderAttribute>();
         if (providerAttribute is not null)
         {
             // look up the requested provider
@@ -153,7 +153,7 @@ public class AutocompleteResponder : IResponder<IInteractionCreate>
         else
         {
             // see if there's an autocomplete provider registered for the parameter type
-            var parameterType = realParameter.ParameterType;
+            var parameterType = realParameter.Parameter.ParameterType;
             var autocompleteProviderType = typeof(IAutocompleteProvider<>).MakeGenericType(parameterType);
             autocompleteProvider = (IAutocompleteProvider?)_services.GetService(autocompleteProviderType);
 


### PR DESCRIPTION
Fixes #352 