### PR TITLE
Replace Fuzzy Matching in EnumAutocompleteProvider to use String.Cont…

### DIFF
--- a/Remora.Discord.Commands/Autocomplete/Providers/EnumAutocompleteProvider.cs
+++ b/Remora.Discord.Commands/Autocomplete/Providers/EnumAutocompleteProvider.cs
@@ -64,7 +64,7 @@ public class EnumAutocompleteProvider<TEnum> : IAutocompleteProvider<TEnum>
         return new ValueTask<IReadOnlyList<IApplicationCommandOptionChoice>>
         (
             choices
-                .OrderByDescending(choice => Fuzz.Ratio(userInput, choice.Name))
+                .Where(choice => choice.Name.Contains(userInput, StringComparison.OrdinalIgnoreCase))
                 .Take(25)
                 .ToList()
         );


### PR DESCRIPTION
This PR replaces fuzzy matching in the built in EnumAutocompleteProvider with a simple String.Contains. I found that you get wildly inconsistent results with the built in Autocomplete Provider. 

Here are some screenshots of what I mean:

With Fuzzy Matching:
![image](https://github.com/user-attachments/assets/d91343c5-0125-4bd7-88a7-905d674a4b5b)

With Contains:
![image](https://github.com/user-attachments/assets/8bd1e0e5-43e1-4b61-b798-11cfc10e0dd2)